### PR TITLE
Started using six

### DIFF
--- a/minecraft/compat.py
+++ b/minecraft/compat.py
@@ -3,17 +3,4 @@ This module stores code used for making pyCraft compatible with
 both Python2 and Python3 while using the same codebase.
 """
 
-# Raw input -> input shenangians
-# example
-# > from minecraft.compat import input
-# > input("asd")
-
-# Hi, I'm pylint, and sometimes I act silly, at which point my programmer
-# overlords need to correct me.
-
-# pylint: disable=undefined-variable,redefined-builtin,invalid-name
-try:
-    input = raw_input
-except NameError:
-    input = input
-# pylint: enable=undefined-variable,redefined-builtin,invalid-name
+# Currently empty, this is sure to grow in time.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography
 requests
+six

--- a/start.py
+++ b/start.py
@@ -6,7 +6,7 @@ from minecraft import authentication
 from minecraft.exceptions import YggdrasilError
 from minecraft.networking.connection import Connection
 from minecraft.networking.packets import ChatMessagePacket, ChatPacket
-from minecraft.compat import input
+from six.moves import input
 
 
 def get_options():

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,8 +1,5 @@
 from minecraft import compat  # noqa unused-import
 
-import unittest
+import unittest  # noqa unused-import
 
-
-class TestCompatInput(unittest.TestCase):
-    def test_import_input(self):
-        from minecraft.compat import input  # noqa unused-import
+# Currently empty, eventually it should grow.

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     nose
     requests
     cryptography
+    six
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
In order to maintain compatibility with both Python 2 and Python 3, I think we should introduce `six` as a dependency.

I know you (@ammaraskar) are not fond of dependencies, but as `pyCraft` grows, I think it would be for the best to use a library such as `six` in order to keep files like `compat.py` to a minimum.

Furthermore, `six` is available as a single file, so if you want to keep pyCraft dependency-free, we can just include six.py in pyCraft.