### PR TITLE
fix AttributeError: 'Packet' object has no attribute 'name'

### DIFF
--- a/minecraft/networking/connection.py
+++ b/minecraft/networking/connection.py
@@ -433,7 +433,7 @@ class NetworkingThread(threading.Thread):
                 # Ignore the earlier exception if a disconnect packet is
                 # received, as it may have been caused by trying to write to
                 # thw closed socket, which does not represent a program error.
-                if exc_info is not None and packet.name == 'disconnect':
+                if exc_info is not None and packet.packet_name == "disconnect":
                     exc_info = None
 
             if exc_info is not None:


### PR DESCRIPTION
I'm somewhat surprised that this flew under the radar for so long but just happen to get this error
```
if exc_info is not None and packet.name == 'disconnect':
AttributeError: 'Packet' object has no attribute 'name'
```
which comes from https://github.com/ammaraskar/pyCraft/blob/master/minecraft/networking/connection.py#L436. By looking at the packet code (https://github.com/ammaraskar/pyCraft/blob/master/minecraft/networking/packets/packet.py#L9) packets only seem to have a ``packet_name`` and not an attribute `name`. Looking at other code inside the connection.py (e.g. https://github.com/ammaraskar/pyCraft/blob/master/minecraft/networking/connection.py#L527) statements like ` if packet.packet_name == "encryption request":` are being used which refer to the somewhat expected `packet_name` and do not use the attribute `name`.

Let me know your thoughts.
PR is very minimalistic ;-)
