### PR TITLE
Position type fix. Add new PlayerBlockPlacementPacket

### DIFF
--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -115,7 +115,8 @@ class PlayerBlockPlacementPacket(Packet):
         packet.location = Position(x=1200, y=65, z=-420)
         packet.face = 2  # 0: Bottom, 1: Top, 2: North, 3: South, 4: West, 5: East
         packet.hand = 0  # 0: Main, 2: Off
-    Next values are called in-block coordinates. They are calculated using raytracing. From 0 to 1:
+    Next values are called in-block coordinates.
+    They are calculated using raytracing. From 0 to 1:
         packet.x = 0.725
         packet.y = 0.125
         packet.z = 0.555"""

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -2,7 +2,7 @@ from minecraft.networking.packets import (
     Packet, PacketBuffer
 )
 from minecraft.networking.types import (
-    VarInt, Integer, UnsignedByte, Position
+    VarInt, Integer, UnsignedByte, Position, Float
 )
 
 

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -29,8 +29,7 @@ class BlockChangePacket(Packet):
 
     def write(self, socket, compression_threshold=None):
         packet_buffer = PacketBuffer()
-        (x, y, z) = self.location
-        Position.send(x, y, z, packet_buffer)
+        Position.send(self.location, packet_buffer)
         blockData = ((self.blockId << 4) | (self.blockMeta & 0xF))
         VarInt.send(blockData)
         self._write_buffer(socket, packet_buffer, compression_threshold)

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -107,3 +107,27 @@ class MultiBlockChangePacket(Packet):
 
     def write(self, socket, compression_threshold=None):
         raise NotImplementedError
+
+
+class PlayerBlockPlacementPacket(Packet):
+    """Realizaton of http://wiki.vg/Protocol#Player_Block_Placement packet
+    Usage:
+        packet = PlayerBlockPlacementPacket()
+        packet.location = Position(x=1200, y=65, z=-420)
+        packet.face = 2  # 0: Bottom, 1: Top, 2: North, 3: South, 4: West, 5: East
+        packet.hand = 0  # 0: Main, 2: Off
+    Next values are called in-block coordinates. They are calculated using raytracing. From 0 to 1:
+        packet.x = 0.725
+        packet.y = 0.125
+        packet.z = 0.555"""
+    id = 0x1F
+    packet_name = 'player block placement'
+    definition = [
+        {'location': Position},
+        {'face': VarInt},
+        {'hand': VarInt},
+        {'x': Float},
+        {'y': Float},
+        {'z': Float},
+    ]
+

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -263,7 +263,8 @@ class Position(Type, namedtuple('Position', ('x', 'y', 'z'))):
         return Position(x=x, y=y, z=z)
 
     @staticmethod
-    def send(x, y, z, socket):
+    def send(cursor_position, socket):
+	"""Cursor_position can be either a tuple or Position object"""
         value = ((x & 0x3FFFFFF) << 38) | ((y & 0xFFF) << 26) | (z & 0x3FFFFFF)
         UnsignedLong.send(value, socket)
 

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -263,8 +263,7 @@ class Position(Type, namedtuple('Position', ('x', 'y', 'z'))):
         return Position(x=x, y=y, z=z)
 
     @staticmethod
-    def send(cursor_position, socket):
-	"""Cursor_position can be either a tuple or Position object"""
+    def send(x, y, z, socket):
         value = ((x & 0x3FFFFFF) << 38) | ((y & 0xFFF) << 26) | (z & 0x3FFFFFF)
         UnsignedLong.send(value, socket)
 

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -263,7 +263,9 @@ class Position(Type, namedtuple('Position', ('x', 'y', 'z'))):
         return Position(x=x, y=y, z=z)
 
     @staticmethod
-    def send(x, y, z, socket):
+    def send(cursor_position, socket):
+        """Cursor_position can be either a tuple or Position object"""
+        x, y, z = cursor_position
         value = ((x & 0x3FFFFFF) << 38) | ((y & 0xFFF) << 26) | (z & 0x3FFFFFF)
         UnsignedLong.send(value, socket)
 


### PR DESCRIPTION
This pull fixes inability to send Position inside Packet. 
Exact error was: `TypeError: send() missing 2 required positional arguments: 'z' and 'socket'`