### PR TITLE
Implement New Type. FixedPointInteger.

### DIFF
--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -3,8 +3,8 @@ from minecraft.networking.packets import (
 )
 
 from minecraft.networking.types import (
-    Integer, UnsignedByte, Byte, Boolean, UUID, Short, VarInt, Double, Float,
-    String, Enum,
+    Integer, FixedPointInteger, UnsignedByte, Byte, Boolean, UUID, Short,
+    VarInt, Double, Float, String, Enum,
 )
 
 from .combat_event_packet import CombatEventPacket
@@ -126,9 +126,12 @@ class SpawnPlayerPacket(Packet):
     get_definition = staticmethod(lambda context: [
         {'entity_id': VarInt},
         {'player_UUID': UUID},
-        {'x': Double} if context.protocol_version >= 100 else {'x': Integer},
-        {'y': Double} if context.protocol_version >= 100 else {'y': Integer},
-        {'z': Double} if context.protocol_version >= 100 else {'z': Integer},
+        {'x': Double} if context.protocol_version >= 100
+        else {'x': FixedPointInteger},
+        {'y': Double} if context.protocol_version >= 100
+        else {'y': FixedPointInteger},
+        {'z': Double} if context.protocol_version >= 100
+        else {'z': FixedPointInteger},
         {'yaw': Float},
         {'pitch': Float},
         # TODO: read entity metadata

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -2,6 +2,7 @@
 Each type has a method which is used to read and write it.
 These definitions and methods are used by the packet definitions
 """
+from __future__ import division
 import struct
 import uuid
 from collections import namedtuple

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -127,7 +127,7 @@ class FixedPointInteger(Type):
 
     @staticmethod
     def send(value, socket):
-        Integer.send(value * 32, socket)
+        Integer.send(int(value * 32), socket)
 
 
 class VarInt(Type):

--- a/minecraft/networking/types.py
+++ b/minecraft/networking/types.py
@@ -120,6 +120,16 @@ class Integer(Type):
         socket.send(struct.pack('>i', value))
 
 
+class FixedPointInteger(Type):
+    @staticmethod
+    def read(file_object):
+        return Integer.read(file_object) / 32
+
+    @staticmethod
+    def send(value, socket):
+        Integer.send(value * 32, socket)
+
+
 class VarInt(Type):
     @staticmethod
     def read(file_object):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,9 +3,9 @@
 import unittest
 from minecraft.networking.types import (
     Type, Boolean, UnsignedByte, Byte, Short, UnsignedShort,
-    Integer, VarInt, Long, Float, Double, ShortPrefixedByteArray,
-    VarIntPrefixedByteArray, UUID, String as StringType, Position,
-    TrailingByteArray, UnsignedLong,
+    Integer, FixedPointInteger, VarInt, Long, Float, Double,
+    ShortPrefixedByteArray, VarIntPrefixedByteArray, UUID,
+    String as StringType, Position, TrailingByteArray, UnsignedLong,
 )
 from minecraft.networking.packets import PacketBuffer
 
@@ -18,6 +18,7 @@ TEST_DATA = {
     UnsignedShort: [0, 400],
     UnsignedLong: [0, 400],
     Integer: [-1000, 1000],
+    FixedPointInteger: [float(-13098.3435), float(-0.83), float(1000)],
     VarInt: [1, 250, 50000, 10000000],
     Long: [50000000],
     Float: [21.000301],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -45,7 +45,10 @@ class SerializationTest(unittest.TestCase):
                     packet_buffer.reset_cursor()
 
                     deserialized = data_type.read(packet_buffer)
-                    if data_type is Float or data_type is Double:
+                    if data_type is FixedPointInteger:
+                        self.assertAlmostEqual(
+                            test_data, deserialized, delta=1.0/32.0)
+                    elif data_type is Float or data_type is Double:
                         self.assertAlmostEquals(test_data, deserialized, 3)
                     else:
                         self.assertEqual(test_data, deserialized)


### PR DESCRIPTION
Signed-off-by: Zachy24

Fixes https://github.com/ammaraskar/pyCraft/issues/92 
Implement new datatype into types.py : "FixedPointInteger".
SpawnPlayerPacket coordinates are now reliable with all protocol versions.
Previously only reliable with versions over 99. (1.8.9).