### PR TITLE
Extend authentication.py to store tokens across sessions

### DIFF
--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -91,10 +91,7 @@ class AuthenticationToken(object):
         self.username = username
         self.access_token = access_token
         self.client_token = client_token
-        self.profile = Profile(
-            id_ = profile_id, 
-            name = profile_name
-        )
+        self.profile = Profile(id_=profile_id, name=profile_name)
 
     @property
     def authenticated(self):
@@ -159,7 +156,7 @@ class AuthenticationToken(object):
             database = launcher_profiles_dict.get('database', {})
             key = self.profile.id_.replace('-', '')
             entry = {
-                'username' : self.username,
+                'username': self.username,
                 'access_token': self.access_token,
                 'profile': {
                     'name': self.profile.name,
@@ -262,12 +259,12 @@ class AuthenticationToken(object):
         res = _make_request(AUTH_SERVER, "signout",
                             {"username": username, "password": password})
 
-        if _raise_from_response(res) is None:     
+        if _raise_from_response(res) is None:
             if launcher_profiles_dict is not None:
                 database = launcher_profiles_dict.get('database', {})
                 for entry in database:
                     if entry['username'] == username:
-                        del database[entry]             
+                        del database[entry]
 
             return True
 

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -215,8 +215,7 @@ class AuthenticationToken(object):
             entry = database.get(key)
 
             entry['access_token'] = self.access_token
-            entry['profile']['name'] = self.profile.name
-            entry['profile']['id'] = self.profile.id_
+            entry['profile'] = self.profile.to_dict
 
         self._authenticated = True
 
@@ -329,6 +328,13 @@ class AuthenticationToken(object):
                              "serverId": server_id})
 
         if res.status_code != 204:
+            # https://wiki.vg/Authentication#Validate
+            # An accessToken may be unusable for authentication with a
+            # Minecraft server, but still be good enough for /refresh.
+            # In this event, we must ensure token is not authentic
+            # and a refresh is necessary.
+            self._authenticated = False
+
             _raise_from_response(res)
 
         return True

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -251,8 +251,7 @@ class AuthenticationToken(object):
         self._authenticated = True
         return True
 
-    @staticmethod
-    def sign_out(username, password, launcher_profiles_dict=None):
+    def sign_out(self, username, password, launcher_profiles_dict=None):
         """
         Invalidates `access_token`s using an account's
         `username` and `password`.

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -236,8 +236,10 @@ class AuthenticationToken(object):
 
         # Validate returns 204 to indicate success
         # http://wiki.vg/Authentication#Response_3
-        if res.status_code == 204:
-            return True
+        if res.status_code != 204:
+            _raise_from_response(res)
+
+        return True
 
     @staticmethod
     def sign_out(username, password, launcher_profiles_dict=None):

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -93,6 +93,8 @@ class AuthenticationToken(object):
         self.client_token = client_token
         self.profile = Profile(id_=profile_id, name=profile_name)
 
+        self._authenticated = False
+
     @property
     def authenticated(self):
         """
@@ -109,6 +111,9 @@ class AuthenticationToken(object):
             return False
 
         if not self.profile:
+            return False
+
+        if not self._authenticated:
             return False
 
         return True
@@ -166,6 +171,8 @@ class AuthenticationToken(object):
 
             database[key] = entry
 
+        self._authenticated = True
+
         return True
 
     def refresh(self, launcher_profiles_dict=None):
@@ -211,6 +218,8 @@ class AuthenticationToken(object):
             entry['profile']['name'] = self.profile.name
             entry['profile']['id'] = self.profile.id_
 
+        self._authenticated = True
+
         return True
 
     def validate(self):
@@ -239,6 +248,7 @@ class AuthenticationToken(object):
         if res.status_code != 204:
             _raise_from_response(res)
 
+        self._authenticated = True
         return True
 
     @staticmethod
@@ -267,6 +277,9 @@ class AuthenticationToken(object):
                 for entry in database:
                     if entry['username'] == username:
                         del database[entry]
+                        break
+
+            self._authenticated = False
 
             return True
 
@@ -287,6 +300,9 @@ class AuthenticationToken(object):
 
         if res.status_code != 204:
             _raise_from_response(res)
+
+        self._authenticated = False
+
         return True
 
     def join(self, server_id):
@@ -315,6 +331,7 @@ class AuthenticationToken(object):
 
         if res.status_code != 204:
             _raise_from_response(res)
+
         return True
 
 

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -163,10 +163,7 @@ class AuthenticationToken(object):
             entry = {
                 'username': self.username,
                 'access_token': self.access_token,
-                'profile': {
-                    'name': self.profile.name,
-                    'id': self.profile.id_
-                }
+                'profile': self.profile.to_dict()
             }
 
             database[key] = entry
@@ -215,7 +212,7 @@ class AuthenticationToken(object):
             entry = database.get(key)
 
             entry['access_token'] = self.access_token
-            entry['profile'] = self.profile.to_dict
+            entry['profile'] = self.profile.to_dict()
 
         self._authenticated = True
 

--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -69,7 +69,14 @@ class AuthenticationToken(object):
     AGENT_NAME = "Minecraft"
     AGENT_VERSION = 1
 
-    def __init__(self, username=None, access_token=None, client_token=None, profile_id=None, profile_name=None):
+    def __init__(
+        self,
+        username=None,
+        access_token=None,
+        client_token=None,
+        profile_id=None,
+        profile_name=None
+    ):
         """
         Constructs an `AuthenticationToken` based on `access_token` and
         `client_token`.


### PR DESCRIPTION
Functions: `authenticate`, `refresh` and `sign_out` now take an optional parameter of a dict.
When a success response is received, the functions will now update the launcher_profiles dict with the newly updated access_token/profile name and uuid.

I also added an Class ProfilesFile() which a user may optionally use as their json dictionary to open and save their launcher_profiles.
This class also generates a version4 uuid for the client_token when no launcher_profiles.json file is found as does the vanilla client.
This client token is specific for that instance of the client and should be used for all future requests with corresponding access tokens. 

Each client only needs one client token and if provided in the payload, the server won't send you a new/different client_token.
See https://wiki.vg/Authentication