### PR TITLE
Fix hanging indefinitely while making auth-related requests (#117)

### DIFF
--- a/minecraft/authentication.py
+++ b/minecraft/authentication.py
@@ -269,7 +269,7 @@ def _make_request(server, endpoint, data):
         A `requests.Request` object.
     """
     res = requests.post(server + "/" + endpoint, data=json.dumps(data),
-                        headers=HEADERS)
+                        headers=HEADERS, timeout=15)
     return res
 
 


### PR DESCRIPTION
Fixes https://github.com/ammaraskar/pyCraft/issues/117

The chosen timeout of 15 seconds is rather arbitrary, I just figured it's a reasonable time to wait for before giving up.

I've decided not to handle the resulting requests.exceptions.Timeout exception as no exception handling is present already. Which, by the way, seems like a mistake to me but perhaps I'm missing something? In any case, it's a separate issue so I didn't attempt to handle the exception here.