### PR TITLE
Update to 1.14

### DIFF
--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -132,6 +132,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '1.13.2-pre1': 402,
     '1.13.2-pre2': 403,
     '1.13.2':      404,
+    '1.14':        477,
 }
 
 SUPPORTED_PROTOCOL_VERSIONS = \

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -47,7 +47,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x21 if context.protocol_version >= 389 else \
+        return 0x20 if context.protocol_version >= 477 else \
+               0x21 if context.protocol_version >= 389 else \
                0x20 if context.protocol_version >= 345 else \
                0x1F if context.protocol_version >= 332 else \
                0x20 if context.protocol_version >= 318 else \
@@ -66,14 +67,15 @@ class JoinGamePacket(Packet):
                0x01
 
     packet_name = "join game"
-    get_definition = staticmethod(lambda context: [
+    get_definition = staticmethod(lambda context: list(filter(None.__ne__, [
         {'entity_id': Integer},
         {'game_mode': UnsignedByte},
         {'dimension': Integer if context.protocol_version >= 108 else Byte},
-        {'difficulty': UnsignedByte},
+        {'difficulty': UnsignedByte} if context.protocol_version < 477 else None,
         {'max_players': UnsignedByte},
         {'level_type': String},
-        {'reduced_debug_info': Boolean}])
+        {'view_distance': VarInt} if context.protocol_version >= 477 else None,
+        {'reduced_debug_info': Boolean}])))
 
 
 class ChatMessagePacket(Packet):
@@ -99,7 +101,8 @@ class ChatMessagePacket(Packet):
 class DisconnectPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x1B if context.protocol_version >= 345 else \
+        return 0x1A if context.protocol_version >= 477 else \
+               0x1B if context.protocol_version >= 345 else \
                0x1A if context.protocol_version >= 332 else \
                0x1B if context.protocol_version >= 318 else \
                0x1A if context.protocol_version >= 107 else \
@@ -145,7 +148,8 @@ class SpawnPlayerPacket(Packet):
 class EntityVelocityPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x41 if context.protocol_version >= 389 else \
+        return 0x45 if context.protocol_version >= 477 else \
+               0x41 if context.protocol_version >= 389 else \
                0x40 if context.protocol_version >= 352 else \
                0x3F if context.protocol_version >= 345 else \
                0x3E if context.protocol_version >= 336 else \
@@ -167,7 +171,8 @@ class EntityVelocityPacket(Packet):
 class UpdateHealthPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x44 if context.protocol_version >= 389 else \
+        return 0x48 if context.protocol_version >= 477 else \
+               0x44 if context.protocol_version >= 389 else \
                0x43 if context.protocol_version >= 352 else \
                0x42 if context.protocol_version >= 345 else \
                0x41 if context.protocol_version >= 336 else \
@@ -188,7 +193,8 @@ class UpdateHealthPacket(Packet):
 class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
-        return 0x19 if context.protocol_version >= 345 else \
+        return 0x18 if context.protocol_version >= 477 else \
+               0x19 if context.protocol_version >= 345 else \
                0x18 if context.protocol_version >= 332 else \
                0x19 if context.protocol_version >= 318 else \
                0x18 if context.protocol_version >= 70 else \
@@ -198,7 +204,8 @@ class PluginMessagePacket(AbstractPluginMessagePacket):
 class PlayerListHeaderAndFooterPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x4E if context.protocol_version >= 393 else \
+        return 0x53 if context.protocol_version >= 477 else \
+               0x4E if context.protocol_version >= 393 else \
                0x4A if context.protocol_version >= 338 else \
                0x49 if context.protocol_version >= 335 else \
                0x47 if context.protocol_version >= 110 else \

--- a/minecraft/networking/packets/clientbound/play/combat_event_packet.py
+++ b/minecraft/networking/packets/clientbound/play/combat_event_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class CombatEventPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2F if context.protocol_version >= 389 else \
+        return 0x32 if context.protocol_version >= 477 else \
+               0x2F if context.protocol_version >= 389 else \
                0x2E if context.protocol_version >= 345 else \
                0x2D if context.protocol_version >= 336 else \
                0x2C if context.protocol_version >= 332 else \

--- a/minecraft/networking/packets/clientbound/play/explosion_packet.py
+++ b/minecraft/networking/packets/clientbound/play/explosion_packet.py
@@ -5,7 +5,8 @@ from minecraft.networking.packets import Packet
 class ExplosionPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x1E if context.protocol_version >= 389 else \
+        return 0x1C if context.protocol_version >= 477 else \
+               0x1E if context.protocol_version >= 389 else \
                0x1D if context.protocol_version >= 345 else \
                0x1C if context.protocol_version >= 332 else \
                0x1D if context.protocol_version >= 318 else \

--- a/minecraft/networking/packets/clientbound/play/map_packet.py
+++ b/minecraft/networking/packets/clientbound/play/map_packet.py
@@ -58,6 +58,11 @@ class MapPacket(Packet):
         else:
             self.is_tracking_position = True
 
+        if self.context.protocol_version >= 477:
+            self.locked = Boolean.read(file_object)
+        else:
+            self.locked = False
+
         icon_count = VarInt.read(file_object)
         self.icons = []
         for i in range(icon_count):

--- a/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class PlayerListItemPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x30 if context.protocol_version >= 389 else \
+        return 0x33 if context.protocol_version >= 477 else \
+               0x30 if context.protocol_version >= 389 else \
                0x2F if context.protocol_version >= 345 else \
                0x2E if context.protocol_version >= 336 else \
                0x2D if context.protocol_version >= 332 else \

--- a/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
     @staticmethod
     def get_id(context):
-        return 0x32 if context.protocol_version >= 389 else \
+        return 0x35 if context.protocol_version >= 477 else \
+               0x32 if context.protocol_version >= 389 else \
                0x31 if context.protocol_version >= 352 else \
                0x30 if context.protocol_version >= 345 else \
                0x2F if context.protocol_version >= 336 else \

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -32,7 +32,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x0E if context.protocol_version >= 389 else \
+        return 0x0F if context.protocol_version >= 477 else \
+               0x0E if context.protocol_version >= 389 else \
                0x0C if context.protocol_version >= 386 else \
                0x0B if context.protocol_version >= 345 else \
                0x0A if context.protocol_version >= 343 else \
@@ -45,7 +46,8 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
 class ChatPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x02 if context.protocol_version >= 389 else \
+        return 0x03 if context.protocol_version >= 477 else \
+               0x02 if context.protocol_version >= 389 else \
                0x01 if context.protocol_version >= 343 else \
                0x02 if context.protocol_version >= 336 else \
                0x03 if context.protocol_version >= 318 else \
@@ -70,7 +72,8 @@ class ChatPacket(Packet):
 class PositionAndLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x11 if context.protocol_version >= 389 else \
+        return 0x12 if context.protocol_version >= 477 else \
+               0x11 if context.protocol_version >= 389 else \
                0x0F if context.protocol_version >= 386 else \
                0x0E if context.protocol_version >= 345 else \
                0x0D if context.protocol_version >= 343 else \
@@ -121,7 +124,8 @@ class AnimationPacket(Packet):
 class ClientStatusPacket(Packet, Enum):
     @staticmethod
     def get_id(context):
-        return 0x03 if context.protocol_version >= 389 else \
+        return 0x04 if context.protocol_version >= 477 else \
+               0x03 if context.protocol_version >= 389 else \
                0x02 if context.protocol_version >= 343 else \
                0x03 if context.protocol_version >= 336 else \
                0x04 if context.protocol_version >= 318 else \
@@ -145,7 +149,8 @@ class ClientStatusPacket(Packet, Enum):
 class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
-        return 0x0A if context.protocol_version >= 389 else \
+        return 0x0B if context.protocol_version >= 477 else \
+               0x0A if context.protocol_version >= 389 else \
                0x09 if context.protocol_version >= 345 else \
                0x08 if context.protocol_version >= 343 else \
                0x09 if context.protocol_version >= 336 else \
@@ -170,7 +175,8 @@ class PlayerBlockPlacementPacket(Packet):
 
     @staticmethod
     def get_id(context):
-        return 0x29 if context.protocol_version >= 389 else \
+        return 0x2C if context.protocol_version >= 477 else \
+               0x29 if context.protocol_version >= 389 else \
                0x27 if context.protocol_version >= 386 else \
                0x1F if context.protocol_version >= 345 else \
                0x1E if context.protocol_version >= 343 else \
@@ -183,14 +189,19 @@ class PlayerBlockPlacementPacket(Packet):
 
     @staticmethod
     def get_definition(context):
-        return [
-            {'location': Position},
-            {'face': VarInt if context.protocol_version >= 69 else Byte},
-            {'hand': VarInt},
+        location = {'location': Position}
+        face = {'face': VarInt if context.protocol_version >= 69 else Byte}
+        hand = {'hand': VarInt}
+        position = [
             {'x': Float if context.protocol_version >= 309 else Byte},
             {'y': Float if context.protocol_version >= 309 else Byte},
             {'z': Float if context.protocol_version >= 309 else Byte},
         ]
+
+        if context.protocol_version >= 477:
+            return [hand, location, face] + position + [{'inside_block': Boolean}]
+        else:
+            return [location, face, hand] + position
 
     # PlayerBlockPlacementPacket.Hand is an alias for RelativeHand.
     Hand = RelativeHand

--- a/minecraft/networking/packets/serverbound/play/client_settings_packet.py
+++ b/minecraft/networking/packets/serverbound/play/client_settings_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class ClientSettingsPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x04 if context.protocol_version >= 389 else \
+        return 0x05 if context.protocol_version >= 477 else \
+               0x04 if context.protocol_version >= 389 else \
                0x03 if context.protocol_version >= 343 else \
                0x04 if context.protocol_version >= 336 else \
                0x05 if context.protocol_version >= 318 else \


### PR DESCRIPTION
This is a bit of a work-in-progress PR, as I still haven't gotten `Position` working right yet.

A question to the developers: is it possible to access the current protocol version from within  a `Type`? The position type was [changed in 1.14](https://wiki.vg/Pre-release_protocol#Position) to be in the order "x, z, y", and as such we are currently reading garbage values. 

If not, I guess we could implement a new `Position` type and use that conditionally, but that seems prone to error and not very optimal design-wise.