### PR TITLE
Support for 1.14.2 (same packet format)

### DIFF
--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -176,6 +176,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '1.14.1 Pre-Release 1': 478,
     '1.14.1 Pre-Release 2': 479,
     '1.14.1':               480,
+    '1.14.2':               485,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,


### PR DESCRIPTION
From my testing and looking at the wiki, the 1.14.2 packet format appears the same, and this simple patch sorts it out.
Thanks for your great work!