### PR TITLE
Compatibility with Poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from minecraft import __version__
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ MAIN_AUTHORS = ["Ammar Askar <ammar@ammaraskar.com>",
 
 URL = "https://github.com/ammaraskar/pyCraft"
 
-setup(name="minecraft",
+setup(name="pyCraft",
       version=__version__,
       description="Python MineCraft library",
       long_description=read("README.rst"),


### PR DESCRIPTION
setuptools is the modern replacement for distutils. Migrating allows pyCraft to be installed with modern Python tooling such as [Poetry](https://poetry.eustace.io/).