### PR TITLE
Added preliminary support for snapshot versions up to 20w12a

### DIFF
--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -231,6 +231,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '20w09a':               704,
     '20w10a':               705,
     '20w11a':               706,
+    '20w12a':               707,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -225,6 +225,12 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '1.15.2-pre1':          576,
     '1.15.2-pre2':          577,
     '1.15.2':               578,
+    '20w06a':               701,
+    '20w07a':               702,
+    '20w08a':               703,
+    '20w09a':               704,
+    '20w10a':               705,
+    '20w11a':               706,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/networking/packets/clientbound/login/__init__.py
+++ b/minecraft/networking/packets/clientbound/login/__init__.py
@@ -1,7 +1,8 @@
 from minecraft.networking.packets import Packet
 
 from minecraft.networking.types import (
-    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray
+    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray,
+    UUIDIntegerArray
 )
 
 
@@ -54,9 +55,11 @@ class LoginSuccessPacket(Packet):
                0x02
 
     packet_name = "login success"
-    definition = [
-        {'UUID': String},
-        {'Username': String}]
+    get_definition = staticmethod(lambda context: [
+        {'UUID': UUIDIntegerArray} if context.protocol_version >= 707
+        else {'UUID': String},
+        {'Username': String}
+    ])
 
 
 class SetCompressionPacket(Packet):

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -206,7 +206,8 @@ class SpawnPlayerPacket(Packet):
 class EntityVelocityPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x46 if context.protocol_version >= 550 else \
+        return 0x47 if context.protocol_version >= 707 else \
+               0x46 if context.protocol_version >= 550 else \
                0x45 if context.protocol_version >= 471 else \
                0x41 if context.protocol_version >= 461 else \
                0x42 if context.protocol_version >= 451 else \
@@ -232,7 +233,8 @@ class EntityVelocityPacket(Packet):
 class UpdateHealthPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x49 if context.protocol_version >= 550 else \
+        return 0x4A if context.protocol_version >= 707 else \
+               0x49 if context.protocol_version >= 550 else \
                0x48 if context.protocol_version >= 471 else \
                0x44 if context.protocol_version >= 461 else \
                0x45 if context.protocol_version >= 451 else \

--- a/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
+++ b/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
@@ -13,7 +13,6 @@ class SoundEffectPacket(Packet):
                0x51 if context.protocol_version >= 471 else \
                0x4D if context.protocol_version >= 461 else \
                0x4E if context.protocol_version >= 451 else \
-               0x4E if context.protocol_version >= 451 else \
                0x4D if context.protocol_version >= 389 else \
                0x4C if context.protocol_version >= 352 else \
                0x4B if context.protocol_version >= 345 else \

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -14,7 +14,7 @@ __all__ = (
     'Integer', 'FixedPointInteger', 'Angle', 'VarInt', 'Long',
     'UnsignedLong', 'Float', 'Double', 'ShortPrefixedByteArray',
     'VarIntPrefixedByteArray', 'TrailingByteArray', 'String', 'UUID',
-    'Position',
+    'Position', 'UUIDIntegerArray'
 )
 
 
@@ -251,6 +251,28 @@ class VarIntPrefixedByteArray(Type):
     def send(value, socket):
         VarInt.send(len(value), socket)
         socket.send(struct.pack(str(len(value)) + "s", value))
+
+
+class UUIDIntegerArray(Type):
+    """ Minecraft sends an array of 4 integers to represent the most
+        significant and least significant bits (as longs) of a UUID
+        because that is how UUIDs are constructed in Java. We need to
+        unpack this array and repack it with the right endianness to be
+        used as a python UUID. """
+    @staticmethod
+    def read(file_object):
+        ints = struct.unpack("4i", file_object.read(4 * 4))
+        packed = struct.pack("<qq", ints[1] << 32 | ints[0] & 0xffffffff,
+            ints[3] << 32 | ints[2] & 0xffffffff)
+        packed_uuid = uuid.UUID(bytes=packed)
+        return str(packed_uuid)
+
+    @staticmethod
+    def send(value, socket):
+        player_uuid = uuid.UUID(value)
+        msb, lsb = struct.unpack(">qq", player_uuid.bytes)
+        socket.send(struct.pack("4i", msb & 0xffffffff, msb >> 32,
+            lsb & 0xffffffff, lsb >> 32))
 
 
 class TrailingByteArray(Type):


### PR DESCRIPTION
Tested working on my snapshot server :)

Changes until 20w11a:
According to wiki.vg the only changes in these protocol versions are related to entity metadata packets pyCraft doesn't implement support for afaik.

Changes in 20w12a:
The UUID for the login success packet is now sent as an array of 4 ints representing 2 longs representing the most significant and least significant bit of a UUID. I added a new type to reflect this change.