### PR TITLE
Added preliminary support for snapshot versions up to 20w13a

### DIFF
--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -231,6 +231,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '20w09a':               704,
     '20w10a':               705,
     '20w11a':               706,
+    '20w12a':               707,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -232,6 +232,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '20w10a':               705,
     '20w11a':               706,
     '20w12a':               707,
+    '20w13a':               708,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -225,6 +225,12 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '1.15.2-pre1':          576,
     '1.15.2-pre2':          577,
     '1.15.2':               578,
+    '20w06a':               701,
+    '20w07a':               702,
+    '20w08a':               703,
+    '20w09a':               704,
+    '20w10a':               705,
+    '20w11a':               706,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/networking/packets/clientbound/login/__init__.py
+++ b/minecraft/networking/packets/clientbound/login/__init__.py
@@ -1,7 +1,8 @@
 from minecraft.networking.packets import Packet
 
 from minecraft.networking.types import (
-    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray
+    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray,
+    UUIDIntegerArray
 )
 
 
@@ -54,9 +55,11 @@ class LoginSuccessPacket(Packet):
                0x02
 
     packet_name = "login success"
-    definition = [
-        {'UUID': String},
-        {'Username': String}]
+    get_definition = staticmethod(lambda context: [
+        {'UUID': UUIDIntegerArray} if context.protocol_version >= 707
+        else {'UUID': String},
+        {'Username': String}
+    ])
 
 
 class SetCompressionPacket(Packet):

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -206,7 +206,8 @@ class SpawnPlayerPacket(Packet):
 class EntityVelocityPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x46 if context.protocol_version >= 550 else \
+        return 0x47 if context.protocol_version >= 707 else \
+               0x46 if context.protocol_version >= 550 else \
                0x45 if context.protocol_version >= 471 else \
                0x41 if context.protocol_version >= 461 else \
                0x42 if context.protocol_version >= 451 else \
@@ -232,7 +233,8 @@ class EntityVelocityPacket(Packet):
 class UpdateHealthPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x49 if context.protocol_version >= 550 else \
+        return 0x4A if context.protocol_version >= 707 else \
+               0x49 if context.protocol_version >= 550 else \
                0x48 if context.protocol_version >= 471 else \
                0x44 if context.protocol_version >= 461 else \
                0x45 if context.protocol_version >= 451 else \

--- a/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
+++ b/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
@@ -13,7 +13,6 @@ class SoundEffectPacket(Packet):
                0x51 if context.protocol_version >= 471 else \
                0x4D if context.protocol_version >= 461 else \
                0x4E if context.protocol_version >= 451 else \
-               0x4E if context.protocol_version >= 451 else \
                0x4D if context.protocol_version >= 389 else \
                0x4C if context.protocol_version >= 352 else \
                0x4B if context.protocol_version >= 345 else \

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -271,8 +271,8 @@ class UUIDIntegerArray(Type):
     def send(value, socket):
         player_uuid = uuid.UUID(value)
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
-        socket.send(struct.pack("4i", msb & 0xffffffff, msb >> 32,
-            lsb & 0xffffffff, lsb >> 32))
+        socket.send(struct.pack("4i", msb, msb >> 32,
+            lsb, lsb >> 32))
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -271,8 +271,8 @@ class UUIDIntegerArray(Type):
     def send(value, socket):
         player_uuid = uuid.UUID(value)
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
-        socket.send(struct.pack("4i", int(str(msb).zfill(20)[:10]), msb >> 32,
-            int(str(lsb).zfill(20)[:10]), lsb >> 32))
+        socket.send(struct.pack(">4i", msb >> 32, msb & 0xffffffff,
+            lsb >> 32, lsb & 0xffffffff))
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -271,8 +271,16 @@ class UUIDIntegerArray(Type):
     def send(value, socket):
         player_uuid = uuid.UUID(value)
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
-        socket.send(struct.pack(">4i", msb >> 32, msb & 0xffffffff,
-            lsb >> 32, lsb & 0xffffffff))
+        socket.send(struct.pack(">4i", msb >> 32, twos_comp(msb & 0xffffffff, 32),
+            lsb >> 32, twos_comp(lsb & 0xffffffff, 32)))
+
+    # https://stackoverflow.com/questions/1604464/twos-complement-in-python
+    @staticmethod
+    def twos_comp(val, bits):
+        """compute the 2's complement of int value val"""
+        if (val & (1 << (bits - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
+            val = val - (1 << bits)        # compute negative value
+        return val                         # return positive value as is
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -253,6 +253,14 @@ class VarIntPrefixedByteArray(Type):
         socket.send(struct.pack(str(len(value)) + "s", value))
 
 
+# https://stackoverflow.com/questions/1604464/twos-complement-in-python
+def twos_comp(val, bits):
+    """compute the 2's complement of int value val"""
+    if (val & (1 << (bits - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
+        val = val - (1 << bits)        # compute negative value
+    return val                         # return positive value as is
+
+
 class UUIDIntegerArray(Type):
     """ Minecraft sends an array of 4 integers to represent the most
         significant and least significant bits (as longs) of a UUID
@@ -273,14 +281,6 @@ class UUIDIntegerArray(Type):
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
         socket.send(struct.pack(">4i", msb >> 32, twos_comp(msb & 0xffffffff, 32),
             lsb >> 32, twos_comp(lsb & 0xffffffff, 32)))
-
-    # https://stackoverflow.com/questions/1604464/twos-complement-in-python
-    @staticmethod
-    def twos_comp(val, bits):
-        """compute the 2's complement of int value val"""
-        if (val & (1 << (bits - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
-            val = val - (1 << bits)        # compute negative value
-        return val                         # return positive value as is
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -271,8 +271,8 @@ class UUIDIntegerArray(Type):
     def send(value, socket):
         player_uuid = uuid.UUID(value)
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
-        socket.send(struct.pack("4i", msb, msb >> 32,
-            lsb, lsb >> 32))
+        socket.send(struct.pack("4i", int(str(msb).zfill(20)[:10]), msb >> 32,
+            int(str(lsb).zfill(20)[:10]), lsb >> 32))
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -256,9 +256,9 @@ class VarIntPrefixedByteArray(Type):
 # https://stackoverflow.com/questions/1604464/twos-complement-in-python
 def twos_comp(val, bits):
     """compute the 2's complement of int value val"""
-    if (val & (1 << (bits - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
-        val = val - (1 << bits)        # compute negative value
-    return val                         # return positive value as is
+    if (val & (1 << (bits - 1))) != 0:  # if sign bit is set
+        val = val - (1 << bits)         # compute negative value
+    return val                          # return positive value as is
 
 
 class UUIDIntegerArray(Type):
@@ -271,7 +271,7 @@ class UUIDIntegerArray(Type):
     def read(file_object):
         ints = struct.unpack("4i", file_object.read(4 * 4))
         packed = struct.pack("<qq", ints[1] << 32 | ints[0] & 0xffffffff,
-            ints[3] << 32 | ints[2] & 0xffffffff)
+                             ints[3] << 32 | ints[2] & 0xffffffff)
         packed_uuid = uuid.UUID(bytes=packed)
         return str(packed_uuid)
 
@@ -279,8 +279,12 @@ class UUIDIntegerArray(Type):
     def send(value, socket):
         player_uuid = uuid.UUID(value)
         msb, lsb = struct.unpack(">qq", player_uuid.bytes)
-        socket.send(struct.pack(">4i", msb >> 32, twos_comp(msb & 0xffffffff, 32),
-            lsb >> 32, twos_comp(lsb & 0xffffffff, 32)))
+        socket.send(struct.pack(">4i", msb >> 32,
+                                twos_comp(msb & 0xffffffff, 32),
+                                lsb >> 32,
+                                twos_comp(lsb & 0xffffffff, 32)
+                                )
+                    )
 
 
 class TrailingByteArray(Type):

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -14,7 +14,7 @@ __all__ = (
     'Integer', 'FixedPointInteger', 'Angle', 'VarInt', 'Long',
     'UnsignedLong', 'Float', 'Double', 'ShortPrefixedByteArray',
     'VarIntPrefixedByteArray', 'TrailingByteArray', 'String', 'UUID',
-    'Position',
+    'Position', 'UUIDIntegerArray'
 )
 
 
@@ -251,6 +251,28 @@ class VarIntPrefixedByteArray(Type):
     def send(value, socket):
         VarInt.send(len(value), socket)
         socket.send(struct.pack(str(len(value)) + "s", value))
+
+
+class UUIDIntegerArray(Type):
+    """ Minecraft sends an array of 4 integers to represent the most
+        significant and least significant bits (as longs) of a UUID
+        because that is how UUIDs are constructed in Java. We need to
+        unpack this array and repack it with the right endianness to be
+        used as a python UUID. """
+    @staticmethod
+    def read(file_object):
+        ints = struct.unpack("4i", file_object.read(4 * 4))
+        packed = struct.pack("<qq", ints[1] << 32 | ints[0] & 0xffffffff,
+            ints[3] << 32 | ints[2] & 0xffffffff)
+        packed_uuid = uuid.UUID(bytes=packed)
+        return str(packed_uuid)
+
+    @staticmethod
+    def send(value, socket):
+        player_uuid = uuid.UUID(value)
+        msb, lsb = struct.unpack(">qq", player_uuid.bytes)
+        socket.send(struct.pack("4i", msb & 0xffffffff, msb >> 32,
+            lsb & 0xffffffff, lsb >> 32))
 
 
 class TrailingByteArray(Type):


### PR DESCRIPTION
Tested working on my snapshot server :)

Changes until 20w11a:
According to wiki.vg the only changes in these protocol versions are related to entity metadata packets pyCraft doesn't implement support for afaik.

Changes in 20w12a:
The UUID for the login success packet is now sent as an array of 4 ints representing 2 longs representing the most significant and least significant bit of a UUID. I added a new type to reflect this change (which for some reason doesn't quite work as expected, I would appreciate any help I can get to fix that).

I'm not exactly sure what's broken in the packet sending code. I bit a bit of testing by packing and unpacking uuids in a debug console on my end and it seems to work with some UUIDs but not others.

For reference, the equivalent java code for packing the UUID is

```java
long lsb, msb;
int[]{(int)(lsb >> 32), (int)lsb, (int)(msb >> 32), (int)msb};
```

Changes in 20w13a:

Nothing interesting in terms of stuff supported by pyCraft