### PR TITLE
Support for 1.16-pre4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "none"
+}

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -225,20 +225,60 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '1.15.2-pre1':          576,
     '1.15.2-pre2':          577,
     '1.15.2':               578,
+    '20w06a':               701,
+    '20w07a':               702,
+    '20w08a':               703,
+    '20w09a':               704,
+    '20w10a':               705,
+    '20w11a':               706,
+    '20w12a':               707,
+    '20w13a':               708,
+    '20w13b':               709,
+    '20w14a':               710,
+    '20w15a':               711,
+    '20w16a':               712,
+    '20w17a':               713,
+    '20w18a':               714,
+    '20w19a':               715,
+    '20w20a':               716,
+    '20w20b':               717,
+    '1.16 Pre-release 2':   722,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,
 # i.e. not development snapshots or pre-release versions.
-RELEASE_MINECRAFT_VERSIONS = {
-    vid: protocol for (vid, protocol) in SUPPORTED_MINECRAFT_VERSIONS.items()
-    if __import__('re').match(r'\d+(\.\d+)+$', vid)}
+RELEASE_MINECRAFT_VERSIONS = {}
 
 # The protocol versions of SUPPORTED_MINECRAFT_VERSIONS, without duplicates,
 # in ascending numerical (and hence chronological) order.
-SUPPORTED_PROTOCOL_VERSIONS = \
-    sorted(set(SUPPORTED_MINECRAFT_VERSIONS.values()))
+SUPPORTED_PROTOCOL_VERSIONS = []
 
 # The protocol versions of RELEASE_MINECRAFT_VERSIONS, without duplicates,
 # in ascending numerical (and hence chronological) order.
-RELEASE_PROTOCOL_VERSIONS = \
-    sorted(set(RELEASE_MINECRAFT_VERSIONS.values()))
+RELEASE_PROTOCOL_VERSIONS = []
+
+
+def initglobals():
+    '''Init the globals from the SUPPORTED_MINECRAFT_VERSIONS dict
+
+    This allows the SUPPORTED_MINECRAFT_VERSIONS dict to be updated, then the
+    other globals can be updated as well, to allow for dynamic version support.
+    All updates are done by reference to allow this to work else where in the code.
+    '''
+    global RELEASE_MINECRAFT_VERSIONS, SUPPORTED_PROTOCOL_VERSIONS, RELEASE_PROTOCOL_VERSIONS
+
+    import re
+
+    for (vid, protocol) in SUPPORTED_MINECRAFT_VERSIONS.items():
+        if re.match(r"\d+(\.\d+)+$", vid):
+            RELEASE_MINECRAFT_VERSIONS[vid] = protocol
+            if protocol not in RELEASE_PROTOCOL_VERSIONS:
+                RELEASE_PROTOCOL_VERSIONS.append(protocol)
+        if protocol not in SUPPORTED_PROTOCOL_VERSIONS:
+            SUPPORTED_PROTOCOL_VERSIONS.append(protocol)
+
+    SUPPORTED_PROTOCOL_VERSIONS.sort()
+    RELEASE_PROTOCOL_VERSIONS.sort()
+
+
+initglobals()

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -244,6 +244,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '20w20b':               717,
     '1.16 Pre-release 2':   722,
     '1.16 Pre-release 3':   725,
+    '1.16 Pre-release 4':   727,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -243,6 +243,7 @@ SUPPORTED_MINECRAFT_VERSIONS = {
     '20w20a':               716,
     '20w20b':               717,
     '1.16 Pre-release 2':   722,
+    '1.16 Pre-release 3':   725,
 }
 
 # Those Minecraft versions supported by pyCraft which are "release" versions,

--- a/minecraft/networking/connection.py
+++ b/minecraft/networking/connection.py
@@ -506,7 +506,10 @@ class Connection(object):
         ss = 'supported, but not allowed for this connection' \
              if server_protocol in SUPPORTED_PROTOCOL_VERSIONS \
              else 'not supported'
-        raise VersionMismatch("Server's %s is %s." % (vs, ss))
+        err = VersionMismatch("Server's %s is %s." % (vs, ss))
+        err.server_protocol = server_protocol
+        err.server_version = server_version
+        raise err
 
     def _handle_exit(self):
         if not self.connected and self.handle_exit is not None:
@@ -647,7 +650,7 @@ class PacketReactor(object):
                 packet.read(packet_data)
                 return packet
             else:
-                return packets.Packet(context=self.connection.context)
+                return packets.Packet(context=self.connection.context, packet_id=packet_id)
         else:
             return None
 

--- a/minecraft/networking/packets/clientbound/login/__init__.py
+++ b/minecraft/networking/packets/clientbound/login/__init__.py
@@ -1,7 +1,8 @@
 from minecraft.networking.packets import Packet
 
 from minecraft.networking.types import (
-    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray
+    VarInt, String, VarIntPrefixedByteArray, TrailingByteArray,
+    UUIDIntegerArray
 )
 
 
@@ -54,9 +55,11 @@ class LoginSuccessPacket(Packet):
                0x02
 
     packet_name = "login success"
-    definition = [
-        {'UUID': String},
-        {'Username': String}]
+    get_definition = staticmethod(lambda context: [
+        {'UUID': UUIDIntegerArray} if context.protocol_version >= 707
+        else {'UUID': String},
+        {'Username': String}
+    ])
 
 
 class SetCompressionPacket(Packet):

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -33,6 +33,8 @@ def get_packets(context):
         DisconnectPacket,
         SpawnPlayerPacket,
         EntityVelocityPacket,
+        EntityPositionDeltaPacket,
+        TimeUpdatePacket,
         UpdateHealthPacket,
         CombatEventPacket,
         ExplosionPacket,
@@ -62,7 +64,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x21 if context.protocol_version >= 550 else \
+        return 0x20 if context.protocol_version >= 722 else \
+               0x21 if context.protocol_version >= 550 else \
                0x20 if context.protocol_version >= 471 else \
                0x21 if context.protocol_version >= 389 else \
                0x20 if context.protocol_version >= 345 else \
@@ -75,7 +78,8 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
 class JoinGamePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x26 if context.protocol_version >= 550 else \
+        return 0x25 if context.protocol_version >= 722 else \
+               0x26 if context.protocol_version >= 550 else \
                0x25 if context.protocol_version >= 389 else \
                0x24 if context.protocol_version >= 345 else \
                0x23 if context.protocol_version >= 332 else \
@@ -91,10 +95,12 @@ class JoinGamePacket(Packet):
         {'hashed_seed': Long} if context.protocol_version >= 552 else {},
         {'difficulty': UnsignedByte} if context.protocol_version < 464 else {},
         {'max_players': UnsignedByte},
-        {'level_type': String},
+        {'level_type': String} if context.protocol_version < 716 else {},
         {'render_distance': VarInt} if context.protocol_version >= 468 else {},
         {'reduced_debug_info': Boolean},
         {'respawn_screen': Boolean} if context.protocol_version >= 571 else {},
+        {'is_debug': Boolean} if context.protocol_version >= 716 else {},
+        {'is_flat': Boolean} if context.protocol_version >= 716 else {},
     ])
 
     # These aliases declare the Enum type corresponding to each field:
@@ -106,7 +112,8 @@ class JoinGamePacket(Packet):
 class ServerDifficultyPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0E if context.protocol_version >= 550 else \
+        return 0x0D if context.protocol_version >= 722 else \
+               0x0E if context.protocol_version >= 550 else \
                0x0D if context.protocol_version >= 332 else \
                0x0E if context.protocol_version >= 318 else \
                0x0D if context.protocol_version >= 70 else \
@@ -125,7 +132,8 @@ class ServerDifficultyPacket(Packet):
 class ChatMessagePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0F if context.protocol_version >= 550 else \
+        return 0x0E if context.protocol_version >= 722 else \
+               0x0F if context.protocol_version >= 550 else \
                0x0E if context.protocol_version >= 343 else \
                0x0F if context.protocol_version >= 332 else \
                0x10 if context.protocol_version >= 317 else \
@@ -146,7 +154,8 @@ class ChatMessagePacket(Packet):
 class DisconnectPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x1B if context.protocol_version >= 550 else \
+        return 0x1A if context.protocol_version >= 722 else \
+               0x1B if context.protocol_version >= 550 else \
                0x1A if context.protocol_version >= 471 else \
                0x1B if context.protocol_version >= 345 else \
                0x1A if context.protocol_version >= 332 else \
@@ -171,7 +180,8 @@ class SetCompressionPacket(Packet):
 class SpawnPlayerPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x05 if context.protocol_version >= 67 else \
+        return 0x04 if context.protocol_version >= 722 else \
+               0x05 if context.protocol_version >= 67 else \
                0x0C
 
     packet_name = 'spawn player'
@@ -206,7 +216,9 @@ class SpawnPlayerPacket(Packet):
 class EntityVelocityPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x46 if context.protocol_version >= 550 else \
+        return 0x46 if context.protocol_version >= 722 else \
+               0x47 if context.protocol_version >= 707 else \
+               0x46 if context.protocol_version >= 550 else \
                0x45 if context.protocol_version >= 471 else \
                0x41 if context.protocol_version >= 461 else \
                0x42 if context.protocol_version >= 451 else \
@@ -229,10 +241,43 @@ class EntityVelocityPacket(Packet):
     ])
 
 
+class EntityPositionDeltaPacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x28 if context.protocol_version >= 722 else \
+               0x29 if context.protocol_version >= 578 else \
+               0xFF
+
+    packet_name = "entity position delta"
+    get_definition = staticmethod(lambda context: [
+        {'entity_id': VarInt},
+        {'delta_x': Short},
+        {'delta_y': Short},
+        {'delta_z': Short},
+        {'on_ground': Boolean}
+    ])
+
+
+class TimeUpdatePacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x4E if context.protocol_version >= 722 else \
+               0x4F if context.protocol_version >= 578 else \
+               0xFF
+
+    packet_name = "time update"
+    get_definition = staticmethod(lambda context: [
+        {'world_age': Long},
+        {'time_of_day': Long},
+    ])
+
+
 class UpdateHealthPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x49 if context.protocol_version >= 550 else \
+        return 0x49 if context.protocol_version >= 722 else \
+               0x4A if context.protocol_version >= 707 else \
+               0x49 if context.protocol_version >= 550 else \
                0x48 if context.protocol_version >= 471 else \
                0x44 if context.protocol_version >= 461 else \
                0x45 if context.protocol_version >= 451 else \
@@ -257,7 +302,8 @@ class UpdateHealthPacket(Packet):
 class RespawnPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x3B if context.protocol_version >= 550 else \
+        return 0x3A if context.protocol_version >= 722 else \
+               0x3B if context.protocol_version >= 550 else \
                0x3A if context.protocol_version >= 471 else \
                0x38 if context.protocol_version >= 461 else \
                0x39 if context.protocol_version >= 451 else \
@@ -276,7 +322,10 @@ class RespawnPacket(Packet):
         {'difficulty': UnsignedByte} if context.protocol_version < 464 else {},
         {'hashed_seed': Long} if context.protocol_version >= 552 else {},
         {'game_mode': UnsignedByte},
-        {'level_type': String},
+        {'level_type': String} if context.protocol_version < 716 else {},
+        {'is_debug': Boolean} if context.protocol_version >= 716 else {},
+        {'is_flat': Boolean} if context.protocol_version >= 716 else {},
+        {'copy_metadata': Boolean},
     ])
 
     # These aliases declare the Enum type corresponding to each field:
@@ -288,7 +337,8 @@ class RespawnPacket(Packet):
 class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
-        return 0x19 if context.protocol_version >= 550 else \
+        return 0x18 if context.protocol_version >= 722 else \
+               0x19 if context.protocol_version >= 550 else \
                0x18 if context.protocol_version >= 471 else \
                0x19 if context.protocol_version >= 345 else \
                0x18 if context.protocol_version >= 332 else \
@@ -300,7 +350,8 @@ class PluginMessagePacket(AbstractPluginMessagePacket):
 class PlayerListHeaderAndFooterPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x54 if context.protocol_version >= 550 else \
+        return 0x53 if context.protocol_version >= 722 else \
+               0x54 if context.protocol_version >= 550 else \
                0x53 if context.protocol_version >= 471 else \
                0x5F if context.protocol_version >= 461 else \
                0x50 if context.protocol_version >= 451 else \
@@ -321,7 +372,8 @@ class PlayerListHeaderAndFooterPacket(Packet):
 class EntityLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2B if context.protocol_version >= 550 else \
+        return 0x2A if context.protocol_version >= 722 else \
+               0x2B if context.protocol_version >= 550 else \
                0x2A if context.protocol_version >= 389 else \
                0x29 if context.protocol_version >= 345 else \
                0x28 if context.protocol_version >= 318 else \

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class BlockChangePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0C if context.protocol_version >= 550 else \
+        return 0x0B if context.protocol_version >= 722 else \
+               0x0C if context.protocol_version >= 550 else \
                0x0B if context.protocol_version >= 332 else \
                0x0C if context.protocol_version >= 318 else \
                0x0B if context.protocol_version >= 67 else \
@@ -46,7 +47,8 @@ class BlockChangePacket(Packet):
 class MultiBlockChangePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x10 if context.protocol_version >= 550 else \
+        return 0x0F if context.protocol_version >= 722 else \
+               0x10 if context.protocol_version >= 550 else \
                0x0F if context.protocol_version >= 343 else \
                0x10 if context.protocol_version >= 332 else \
                0x11 if context.protocol_version >= 318 else \

--- a/minecraft/networking/packets/clientbound/play/combat_event_packet.py
+++ b/minecraft/networking/packets/clientbound/play/combat_event_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class CombatEventPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x33 if context.protocol_version >= 550 else \
+        return 0x32 if context.protocol_version >= 722 else \
+               0x33 if context.protocol_version >= 550 else \
                0x32 if context.protocol_version >= 471 else \
                0x30 if context.protocol_version >= 451 else \
                0x2F if context.protocol_version >= 389 else \

--- a/minecraft/networking/packets/clientbound/play/explosion_packet.py
+++ b/minecraft/networking/packets/clientbound/play/explosion_packet.py
@@ -7,7 +7,8 @@ from minecraft.networking.packets import Packet
 class ExplosionPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x1D if context.protocol_version >= 550 else \
+        return 0x1C if context.protocol_version >= 722 else \
+               0x1D if context.protocol_version >= 550 else \
                0x1C if context.protocol_version >= 471 else \
                0x1E if context.protocol_version >= 389 else \
                0x1D if context.protocol_version >= 345 else \

--- a/minecraft/networking/packets/clientbound/play/face_player_packet.py
+++ b/minecraft/networking/packets/clientbound/play/face_player_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.packets import Packet
 class FacePlayerPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x35 if context.protocol_version >= 550 else \
+        return 0x34 if context.protocol_version >= 722 else \
+               0x35 if context.protocol_version >= 550 else \
                0x34 if context.protocol_version >= 471 else \
                0x32 if context.protocol_version >= 451 else \
                0x31 if context.protocol_version >= 389 else \

--- a/minecraft/networking/packets/clientbound/play/map_packet.py
+++ b/minecraft/networking/packets/clientbound/play/map_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class MapPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x27 if context.protocol_version >= 550 else \
+        return 0x26 if context.protocol_version >= 722 else \
+               0x27 if context.protocol_version >= 550 else \
                0x26 if context.protocol_version >= 389 else \
                0x25 if context.protocol_version >= 345 else \
                0x24 if context.protocol_version >= 334 else \

--- a/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
@@ -9,7 +9,8 @@ from minecraft.networking.types import (
 class PlayerListItemPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x34 if context.protocol_version >= 550 else \
+        return 0x33 if context.protocol_version >= 722 else \
+               0x34 if context.protocol_version >= 550 else \
                0x33 if context.protocol_version >= 471 else \
                0x31 if context.protocol_version >= 451 else \
                0x30 if context.protocol_version >= 389 else \

--- a/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
@@ -9,7 +9,8 @@ from minecraft.networking.types import (
 class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
     @staticmethod
     def get_id(context):
-        return 0x36 if context.protocol_version >= 550 else \
+        return 0x35 if context.protocol_version >= 722 else \
+               0x36 if context.protocol_version >= 550 else \
                0x35 if context.protocol_version >= 471 else \
                0x33 if context.protocol_version >= 451 else \
                0x32 if context.protocol_version >= 389 else \

--- a/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
+++ b/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
@@ -9,10 +9,10 @@ __all__ = 'SoundEffectPacket',
 class SoundEffectPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x52 if context.protocol_version >= 550 else \
+        return 0x51 if context.protocol_version >= 722 else \
+               0x52 if context.protocol_version >= 550 else \
                0x51 if context.protocol_version >= 471 else \
                0x4D if context.protocol_version >= 461 else \
-               0x4E if context.protocol_version >= 451 else \
                0x4E if context.protocol_version >= 451 else \
                0x4D if context.protocol_version >= 389 else \
                0x4C if context.protocol_version >= 352 else \

--- a/minecraft/networking/packets/clientbound/play/spawn_object_packet.py
+++ b/minecraft/networking/packets/clientbound/play/spawn_object_packet.py
@@ -49,6 +49,7 @@ class SpawnObjectPacket(Packet):
             return getattr(cls, name)
 
         class EntityType(Enum):
+            # XXX This has not been updated for >= v1.15
             ACTIVATED_TNT     = 50 if pv < 458 else 55  # PrimedTnt
             AREA_EFFECT_CLOUD =  3 if pv < 458 else  0
             ARMORSTAND        = 78 if pv < 458 else  1

--- a/minecraft/networking/packets/packet.py
+++ b/minecraft/networking/packets/packet.py
@@ -110,6 +110,8 @@ class Packet(object):
         str = type(self).__name__
         if self.id is not None:
             str = '0x%02X %s' % (self.id, str)
+        elif hasattr(self, "packet_id"):
+            str = 'pkt: 0x%02X %s' % (self.packet_id, str)
         fields = self.fields
         if fields is not None:
             inner_str = ', '.join('%s=%s' % (a, self.field_string(a))

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -5,7 +5,7 @@ from minecraft.networking.packets import (
 from minecraft.networking.types import (
     Double, Float, Boolean, VarInt, String, Byte, Position, Enum,
     RelativeHand, BlockFace, Vector, Direction, PositionAndLook,
-    multi_attribute_alias
+    multi_attribute_alias, Short
 )
 
 from .client_settings_packet import ClientSettingsPacket
@@ -37,7 +37,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x0F if context.protocol_version >= 471 else \
+        return 0x10 if context.protocol_version >= 712 else \
+               0x0F if context.protocol_version >= 471 else \
                0x10 if context.protocol_version >= 464 else \
                0x0E if context.protocol_version >= 389 else \
                0x0C if context.protocol_version >= 386 else \
@@ -78,7 +79,8 @@ class ChatPacket(Packet):
 class PositionAndLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x12 if context.protocol_version >= 471 else \
+        return 0x13 if context.protocol_version >= 712 else \
+               0x12 if context.protocol_version >= 471 else \
                0x13 if context.protocol_version >= 464 else \
                0x11 if context.protocol_version >= 389 else \
                0x0F if context.protocol_version >= 386 else \
@@ -124,7 +126,8 @@ class TeleportConfirmPacket(Packet):
 class AnimationPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2A if context.protocol_version >= 468 else \
+        return 0x2B if context.protocol_version >= 719 else \
+               0x2A if context.protocol_version >= 468 else \
                0x29 if context.protocol_version >= 464 else \
                0x27 if context.protocol_version >= 389 else \
                0x25 if context.protocol_version >= 386 else \
@@ -197,7 +200,8 @@ class PlayerBlockPlacementPacket(Packet):
 
     @staticmethod
     def get_id(context):
-        return 0x2C if context.protocol_version >= 468 else \
+        return 0x2D if context.protocol_version >= 712 else \
+               0x2C if context.protocol_version >= 468 else \
                0x2B if context.protocol_version >= 464 else \
                0x29 if context.protocol_version >= 389 else \
                0x27 if context.protocol_version >= 386 else \
@@ -234,7 +238,8 @@ class PlayerBlockPlacementPacket(Packet):
 class UseItemPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2D if context.protocol_version >= 468 else \
+        return 0x2E if context.protocol_version >= 719 else \
+               0x2D if context.protocol_version >= 468 else \
                0x2C if context.protocol_version >= 464 else \
                0x2A if context.protocol_version >= 389 else \
                0x28 if context.protocol_version >= 386 else \

--- a/minecraft/networking/types/basic.py
+++ b/minecraft/networking/types/basic.py
@@ -14,7 +14,7 @@ __all__ = (
     'Integer', 'FixedPointInteger', 'Angle', 'VarInt', 'Long',
     'UnsignedLong', 'Float', 'Double', 'ShortPrefixedByteArray',
     'VarIntPrefixedByteArray', 'TrailingByteArray', 'String', 'UUID',
-    'Position',
+    'Position', 'UUIDIntegerArray'
 )
 
 
@@ -251,6 +251,40 @@ class VarIntPrefixedByteArray(Type):
     def send(value, socket):
         VarInt.send(len(value), socket)
         socket.send(struct.pack(str(len(value)) + "s", value))
+
+
+# https://stackoverflow.com/questions/1604464/twos-complement-in-python
+def twos_comp(val, bits):
+    """compute the 2's complement of int value val"""
+    if (val & (1 << (bits - 1))) != 0:  # if sign bit is set
+        val = val - (1 << bits)         # compute negative value
+    return val                          # return positive value as is
+
+
+class UUIDIntegerArray(Type):
+    """ Minecraft sends an array of 4 integers to represent the most
+        significant and least significant bits (as longs) of a UUID
+        because that is how UUIDs are constructed in Java. We need to
+        unpack this array and repack it with the right endianness to be
+        used as a python UUID. """
+    @staticmethod
+    def read(file_object):
+        ints = struct.unpack("4i", file_object.read(4 * 4))
+        packed = struct.pack("<qq", ints[1] << 32 | ints[0] & 0xffffffff,
+                             ints[3] << 32 | ints[2] & 0xffffffff)
+        packed_uuid = uuid.UUID(bytes=packed)
+        return str(packed_uuid)
+
+    @staticmethod
+    def send(value, socket):
+        player_uuid = uuid.UUID(value)
+        msb, lsb = struct.unpack(">qq", player_uuid.bytes)
+        socket.send(struct.pack(">4i", msb >> 32,
+                                twos_comp(msb & 0xffffffff, 32),
+                                lsb >> 32,
+                                twos_comp(lsb & 0xffffffff, 32)
+                                )
+                    )
 
 
 class TrailingByteArray(Type):

--- a/start.py
+++ b/start.py
@@ -35,6 +35,10 @@ def get_options():
                       action="store_true",
                       help="print sent and received packets to standard error")
 
+    parser.add_option("-v", "--dump-unknown-packets", dest="dump_unknown",
+                      action="store_true",
+                      help="include unknown packets in --dump-packets output")
+
     (options, args) = parser.parse_args()
 
     if not options.username:
@@ -82,6 +86,8 @@ def main():
             if type(packet) is Packet:
                 # This is a direct instance of the base Packet type, meaning
                 # that it is a packet of unknown type, so we do not print it.
+                if options.dump_unknown:
+                    print('--> ??? %s' % packet, file=sys.stderr)
                 return
             print('--> %s' % packet, file=sys.stderr)
 


### PR DESCRIPTION
This builds on to of the work by starcraft66 in #168 (replacing that PR I think). There has been a big change in the protocol since the snapshots (most clientbound values have reduced by 1). I have tested with the the current 1.16-pre2 server and client, and all appears to work, including most packets firing as expected. Unfortunately these changes are not yet up at https://wiki.vg/ - so much of this was trial and error, figuring out what had changed since the last release.

It also includes a few things to assist in debugging, that does not change the core API.

Thanks!