### PR TITLE
Added serverbound HeldItemChange packet

### DIFF
--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -23,7 +23,7 @@ def get_packets(context):
         ClientSettingsPacket,
         PluginMessagePacket,
         PlayerBlockPlacementPacket,
-        HeldItemChangePacket
+        HeldItemChangePacket,
     }
     if context.protocol_version >= 69:
         packets |= {
@@ -40,33 +40,33 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
         return 0x10 if context.protocol_version >= 712 else \
-            0x0F if context.protocol_version >= 471 else \
-            0x10 if context.protocol_version >= 464 else \
-            0x0E if context.protocol_version >= 389 else \
-            0x0C if context.protocol_version >= 386 else \
-            0x0B if context.protocol_version >= 345 else \
-            0x0A if context.protocol_version >= 343 else \
-            0x0B if context.protocol_version >= 336 else \
-            0x0C if context.protocol_version >= 318 else \
-            0x0B if context.protocol_version >= 107 else \
-            0x00
+               0x0F if context.protocol_version >= 471 else \
+               0x10 if context.protocol_version >= 464 else \
+               0x0E if context.protocol_version >= 389 else \
+               0x0C if context.protocol_version >= 386 else \
+               0x0B if context.protocol_version >= 345 else \
+               0x0A if context.protocol_version >= 343 else \
+               0x0B if context.protocol_version >= 336 else \
+               0x0C if context.protocol_version >= 318 else \
+               0x0B if context.protocol_version >= 107 else \
+               0x00
 
 
 class ChatPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x03 if context.protocol_version >= 464 else \
-            0x02 if context.protocol_version >= 389 else \
-            0x01 if context.protocol_version >= 343 else \
-            0x02 if context.protocol_version >= 336 else \
-            0x03 if context.protocol_version >= 318 else \
-            0x02 if context.protocol_version >= 107 else \
-            0x01
+               0x02 if context.protocol_version >= 389 else \
+               0x01 if context.protocol_version >= 343 else \
+               0x02 if context.protocol_version >= 336 else \
+               0x03 if context.protocol_version >= 318 else \
+               0x02 if context.protocol_version >= 107 else \
+               0x01
 
     @staticmethod
     def get_max_length(context):
         return 256 if context.protocol_version >= 306 else \
-            100
+               100
 
     @property
     def max_length(self):
@@ -82,17 +82,17 @@ class PositionAndLookPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x13 if context.protocol_version >= 712 else \
-            0x12 if context.protocol_version >= 471 else \
-            0x13 if context.protocol_version >= 464 else \
-            0x11 if context.protocol_version >= 389 else \
-            0x0F if context.protocol_version >= 386 else \
-            0x0E if context.protocol_version >= 345 else \
-            0x0D if context.protocol_version >= 343 else \
-            0x0E if context.protocol_version >= 336 else \
-            0x0F if context.protocol_version >= 332 else \
-            0x0E if context.protocol_version >= 318 else \
-            0x0D if context.protocol_version >= 107 else \
-            0x06
+               0x12 if context.protocol_version >= 471 else \
+               0x13 if context.protocol_version >= 464 else \
+               0x11 if context.protocol_version >= 389 else \
+               0x0F if context.protocol_version >= 386 else \
+               0x0E if context.protocol_version >= 345 else \
+               0x0D if context.protocol_version >= 343 else \
+               0x0E if context.protocol_version >= 336 else \
+               0x0F if context.protocol_version >= 332 else \
+               0x0E if context.protocol_version >= 318 else \
+               0x0D if context.protocol_version >= 107 else \
+               0x06
 
     packet_name = "position and look"
     definition = [
@@ -129,17 +129,17 @@ class AnimationPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2C if context.protocol_version >= 738 else \
-            0x2B if context.protocol_version >= 712 else \
-            0x2A if context.protocol_version >= 468 else \
-            0x29 if context.protocol_version >= 464 else \
-            0x27 if context.protocol_version >= 389 else \
-            0x25 if context.protocol_version >= 386 else \
-            0x1D if context.protocol_version >= 345 else \
-            0x1C if context.protocol_version >= 343 else \
-            0x1D if context.protocol_version >= 332 else \
-            0x1C if context.protocol_version >= 318 else \
-            0x1A if context.protocol_version >= 107 else \
-            0x0A
+               0x2B if context.protocol_version >= 712 else \
+               0x2A if context.protocol_version >= 468 else \
+               0x29 if context.protocol_version >= 464 else \
+               0x27 if context.protocol_version >= 389 else \
+               0x25 if context.protocol_version >= 386 else \
+               0x1D if context.protocol_version >= 345 else \
+               0x1C if context.protocol_version >= 343 else \
+               0x1D if context.protocol_version >= 332 else \
+               0x1C if context.protocol_version >= 318 else \
+               0x1A if context.protocol_version >= 107 else \
+               0x0A
 
     packet_name = "animation"
     get_definition = staticmethod(lambda context: [
@@ -153,14 +153,14 @@ class ClientStatusPacket(Packet, Enum):
     @staticmethod
     def get_id(context):
         return 0x04 if context.protocol_version >= 464 else \
-            0x03 if context.protocol_version >= 389 else \
-            0x02 if context.protocol_version >= 343 else \
-            0x03 if context.protocol_version >= 336 else \
-            0x04 if context.protocol_version >= 318 else \
-            0x03 if context.protocol_version >= 80 else \
-            0x02 if context.protocol_version >= 67 else \
-            0x17 if context.protocol_version >= 49 else \
-            0x16
+               0x03 if context.protocol_version >= 389 else \
+               0x02 if context.protocol_version >= 343 else \
+               0x03 if context.protocol_version >= 336 else \
+               0x04 if context.protocol_version >= 318 else \
+               0x03 if context.protocol_version >= 80 else \
+               0x02 if context.protocol_version >= 67 else \
+               0x17 if context.protocol_version >= 49 else \
+               0x16
 
     packet_name = "client status"
     get_definition = staticmethod(lambda context: [
@@ -178,13 +178,13 @@ class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
         return 0x0B if context.protocol_version >= 464 else \
-            0x0A if context.protocol_version >= 389 else \
-            0x09 if context.protocol_version >= 345 else \
-            0x08 if context.protocol_version >= 343 else \
-            0x09 if context.protocol_version >= 336 else \
-            0x0A if context.protocol_version >= 317 else \
-            0x09 if context.protocol_version >= 94 else \
-            0x17
+               0x0A if context.protocol_version >= 389 else \
+               0x09 if context.protocol_version >= 345 else \
+               0x08 if context.protocol_version >= 343 else \
+               0x09 if context.protocol_version >= 336 else \
+               0x0A if context.protocol_version >= 317 else \
+               0x09 if context.protocol_version >= 94 else \
+               0x17
 
 
 class PlayerBlockPlacementPacket(Packet):
@@ -204,17 +204,17 @@ class PlayerBlockPlacementPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2E if context.protocol_version >= 738 else \
-            0x2D if context.protocol_version >= 712 else \
-            0x2C if context.protocol_version >= 468 else \
-            0x2B if context.protocol_version >= 464 else \
-            0x29 if context.protocol_version >= 389 else \
-            0x27 if context.protocol_version >= 386 else \
-            0x1F if context.protocol_version >= 345 else \
-            0x1E if context.protocol_version >= 343 else \
-            0x1F if context.protocol_version >= 332 else \
-            0x1E if context.protocol_version >= 318 else \
-            0x1C if context.protocol_version >= 94 else \
-            0x08
+               0x2D if context.protocol_version >= 712 else \
+               0x2C if context.protocol_version >= 468 else \
+               0x2B if context.protocol_version >= 464 else \
+               0x29 if context.protocol_version >= 389 else \
+               0x27 if context.protocol_version >= 386 else \
+               0x1F if context.protocol_version >= 345 else \
+               0x1E if context.protocol_version >= 343 else \
+               0x1F if context.protocol_version >= 332 else \
+               0x1E if context.protocol_version >= 318 else \
+               0x1C if context.protocol_version >= 94 else \
+               0x08
 
     packet_name = 'player block placement'
 
@@ -243,18 +243,18 @@ class UseItemPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2F if context.protocol_version >= 738 else \
-            0x2E if context.protocol_version >= 712 else \
-            0x2D if context.protocol_version >= 468 else \
-            0x2C if context.protocol_version >= 464 else \
-            0x2A if context.protocol_version >= 389 else \
-            0x28 if context.protocol_version >= 386 else \
-            0x20 if context.protocol_version >= 345 else \
-            0x1F if context.protocol_version >= 343 else \
-            0x20 if context.protocol_version >= 332 else \
-            0x1F if context.protocol_version >= 318 else \
-            0x1D if context.protocol_version >= 94 else \
-            0x1A if context.protocol_version >= 70 else \
-            0x08
+               0x2E if context.protocol_version >= 712 else \
+               0x2D if context.protocol_version >= 468 else \
+               0x2C if context.protocol_version >= 464 else \
+               0x2A if context.protocol_version >= 389 else \
+               0x28 if context.protocol_version >= 386 else \
+               0x20 if context.protocol_version >= 345 else \
+               0x1F if context.protocol_version >= 343 else \
+               0x20 if context.protocol_version >= 332 else \
+               0x1F if context.protocol_version >= 318 else \
+               0x1D if context.protocol_version >= 94 else \
+               0x1A if context.protocol_version >= 70 else \
+               0x08
 
     packet_name = "use item"
     get_definition = staticmethod(lambda context: [

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -9,6 +9,7 @@ from minecraft.networking.types import (
 )
 
 from .client_settings_packet import ClientSettingsPacket
+from .held_item_change_packet import HeldItemChangePacket
 
 
 # Formerly known as state_playing_serverbound.
@@ -22,6 +23,7 @@ def get_packets(context):
         ClientSettingsPacket,
         PluginMessagePacket,
         PlayerBlockPlacementPacket,
+        HeldItemChangePacket
     }
     if context.protocol_version >= 69:
         packets |= {
@@ -38,33 +40,33 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
         return 0x10 if context.protocol_version >= 712 else \
-               0x0F if context.protocol_version >= 471 else \
-               0x10 if context.protocol_version >= 464 else \
-               0x0E if context.protocol_version >= 389 else \
-               0x0C if context.protocol_version >= 386 else \
-               0x0B if context.protocol_version >= 345 else \
-               0x0A if context.protocol_version >= 343 else \
-               0x0B if context.protocol_version >= 336 else \
-               0x0C if context.protocol_version >= 318 else \
-               0x0B if context.protocol_version >= 107 else \
-               0x00
+            0x0F if context.protocol_version >= 471 else \
+            0x10 if context.protocol_version >= 464 else \
+            0x0E if context.protocol_version >= 389 else \
+            0x0C if context.protocol_version >= 386 else \
+            0x0B if context.protocol_version >= 345 else \
+            0x0A if context.protocol_version >= 343 else \
+            0x0B if context.protocol_version >= 336 else \
+            0x0C if context.protocol_version >= 318 else \
+            0x0B if context.protocol_version >= 107 else \
+            0x00
 
 
 class ChatPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x03 if context.protocol_version >= 464 else \
-               0x02 if context.protocol_version >= 389 else \
-               0x01 if context.protocol_version >= 343 else \
-               0x02 if context.protocol_version >= 336 else \
-               0x03 if context.protocol_version >= 318 else \
-               0x02 if context.protocol_version >= 107 else \
-               0x01
+            0x02 if context.protocol_version >= 389 else \
+            0x01 if context.protocol_version >= 343 else \
+            0x02 if context.protocol_version >= 336 else \
+            0x03 if context.protocol_version >= 318 else \
+            0x02 if context.protocol_version >= 107 else \
+            0x01
 
     @staticmethod
     def get_max_length(context):
         return 256 if context.protocol_version >= 306 else \
-               100
+            100
 
     @property
     def max_length(self):
@@ -80,17 +82,17 @@ class PositionAndLookPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x13 if context.protocol_version >= 712 else \
-               0x12 if context.protocol_version >= 471 else \
-               0x13 if context.protocol_version >= 464 else \
-               0x11 if context.protocol_version >= 389 else \
-               0x0F if context.protocol_version >= 386 else \
-               0x0E if context.protocol_version >= 345 else \
-               0x0D if context.protocol_version >= 343 else \
-               0x0E if context.protocol_version >= 336 else \
-               0x0F if context.protocol_version >= 332 else \
-               0x0E if context.protocol_version >= 318 else \
-               0x0D if context.protocol_version >= 107 else \
-               0x06
+            0x12 if context.protocol_version >= 471 else \
+            0x13 if context.protocol_version >= 464 else \
+            0x11 if context.protocol_version >= 389 else \
+            0x0F if context.protocol_version >= 386 else \
+            0x0E if context.protocol_version >= 345 else \
+            0x0D if context.protocol_version >= 343 else \
+            0x0E if context.protocol_version >= 336 else \
+            0x0F if context.protocol_version >= 332 else \
+            0x0E if context.protocol_version >= 318 else \
+            0x0D if context.protocol_version >= 107 else \
+            0x06
 
     packet_name = "position and look"
     definition = [
@@ -127,17 +129,17 @@ class AnimationPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2C if context.protocol_version >= 738 else \
-               0x2B if context.protocol_version >= 712 else \
-               0x2A if context.protocol_version >= 468 else \
-               0x29 if context.protocol_version >= 464 else \
-               0x27 if context.protocol_version >= 389 else \
-               0x25 if context.protocol_version >= 386 else \
-               0x1D if context.protocol_version >= 345 else \
-               0x1C if context.protocol_version >= 343 else \
-               0x1D if context.protocol_version >= 332 else \
-               0x1C if context.protocol_version >= 318 else \
-               0x1A if context.protocol_version >= 107 else \
-               0x0A
+            0x2B if context.protocol_version >= 712 else \
+            0x2A if context.protocol_version >= 468 else \
+            0x29 if context.protocol_version >= 464 else \
+            0x27 if context.protocol_version >= 389 else \
+            0x25 if context.protocol_version >= 386 else \
+            0x1D if context.protocol_version >= 345 else \
+            0x1C if context.protocol_version >= 343 else \
+            0x1D if context.protocol_version >= 332 else \
+            0x1C if context.protocol_version >= 318 else \
+            0x1A if context.protocol_version >= 107 else \
+            0x0A
 
     packet_name = "animation"
     get_definition = staticmethod(lambda context: [
@@ -151,14 +153,14 @@ class ClientStatusPacket(Packet, Enum):
     @staticmethod
     def get_id(context):
         return 0x04 if context.protocol_version >= 464 else \
-               0x03 if context.protocol_version >= 389 else \
-               0x02 if context.protocol_version >= 343 else \
-               0x03 if context.protocol_version >= 336 else \
-               0x04 if context.protocol_version >= 318 else \
-               0x03 if context.protocol_version >= 80 else \
-               0x02 if context.protocol_version >= 67 else \
-               0x17 if context.protocol_version >= 49 else \
-               0x16
+            0x03 if context.protocol_version >= 389 else \
+            0x02 if context.protocol_version >= 343 else \
+            0x03 if context.protocol_version >= 336 else \
+            0x04 if context.protocol_version >= 318 else \
+            0x03 if context.protocol_version >= 80 else \
+            0x02 if context.protocol_version >= 67 else \
+            0x17 if context.protocol_version >= 49 else \
+            0x16
 
     packet_name = "client status"
     get_definition = staticmethod(lambda context: [
@@ -176,13 +178,13 @@ class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
         return 0x0B if context.protocol_version >= 464 else \
-               0x0A if context.protocol_version >= 389 else \
-               0x09 if context.protocol_version >= 345 else \
-               0x08 if context.protocol_version >= 343 else \
-               0x09 if context.protocol_version >= 336 else \
-               0x0A if context.protocol_version >= 317 else \
-               0x09 if context.protocol_version >= 94 else \
-               0x17
+            0x0A if context.protocol_version >= 389 else \
+            0x09 if context.protocol_version >= 345 else \
+            0x08 if context.protocol_version >= 343 else \
+            0x09 if context.protocol_version >= 336 else \
+            0x0A if context.protocol_version >= 317 else \
+            0x09 if context.protocol_version >= 94 else \
+            0x17
 
 
 class PlayerBlockPlacementPacket(Packet):
@@ -202,17 +204,17 @@ class PlayerBlockPlacementPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2E if context.protocol_version >= 738 else \
-               0x2D if context.protocol_version >= 712 else \
-               0x2C if context.protocol_version >= 468 else \
-               0x2B if context.protocol_version >= 464 else \
-               0x29 if context.protocol_version >= 389 else \
-               0x27 if context.protocol_version >= 386 else \
-               0x1F if context.protocol_version >= 345 else \
-               0x1E if context.protocol_version >= 343 else \
-               0x1F if context.protocol_version >= 332 else \
-               0x1E if context.protocol_version >= 318 else \
-               0x1C if context.protocol_version >= 94 else \
-               0x08
+            0x2D if context.protocol_version >= 712 else \
+            0x2C if context.protocol_version >= 468 else \
+            0x2B if context.protocol_version >= 464 else \
+            0x29 if context.protocol_version >= 389 else \
+            0x27 if context.protocol_version >= 386 else \
+            0x1F if context.protocol_version >= 345 else \
+            0x1E if context.protocol_version >= 343 else \
+            0x1F if context.protocol_version >= 332 else \
+            0x1E if context.protocol_version >= 318 else \
+            0x1C if context.protocol_version >= 94 else \
+            0x08
 
     packet_name = 'player block placement'
 
@@ -241,18 +243,18 @@ class UseItemPacket(Packet):
     @staticmethod
     def get_id(context):
         return 0x2F if context.protocol_version >= 738 else \
-               0x2E if context.protocol_version >= 712 else \
-               0x2D if context.protocol_version >= 468 else \
-               0x2C if context.protocol_version >= 464 else \
-               0x2A if context.protocol_version >= 389 else \
-               0x28 if context.protocol_version >= 386 else \
-               0x20 if context.protocol_version >= 345 else \
-               0x1F if context.protocol_version >= 343 else \
-               0x20 if context.protocol_version >= 332 else \
-               0x1F if context.protocol_version >= 318 else \
-               0x1D if context.protocol_version >= 94 else \
-               0x1A if context.protocol_version >= 70 else \
-               0x08
+            0x2E if context.protocol_version >= 712 else \
+            0x2D if context.protocol_version >= 468 else \
+            0x2C if context.protocol_version >= 464 else \
+            0x2A if context.protocol_version >= 389 else \
+            0x28 if context.protocol_version >= 386 else \
+            0x20 if context.protocol_version >= 345 else \
+            0x1F if context.protocol_version >= 343 else \
+            0x20 if context.protocol_version >= 332 else \
+            0x1F if context.protocol_version >= 318 else \
+            0x1D if context.protocol_version >= 94 else \
+            0x1A if context.protocol_version >= 70 else \
+            0x08
 
     packet_name = "use item"
     get_definition = staticmethod(lambda context: [

--- a/minecraft/networking/packets/serverbound/play/held_item_change_packet.py
+++ b/minecraft/networking/packets/serverbound/play/held_item_change_packet.py
@@ -8,7 +8,19 @@ from minecraft.networking.types import (
 class HeldItemChangePacket(Packet, BitFieldEnum):
     @staticmethod
     def get_id(context):
-        return 0x25
+        return 0x25 if context.protocol_version >= 738 else \
+            0x24 if context.protocol_version >= 712 else \
+            0x23 if context.protocol_version >= 464 else \
+            0x21 if context.protocol_version >= 389 else \
+            0x1F if context.protocol_version >= 386 else \
+            0x1A if context.protocol_version >= 345 else \
+            0x19 if context.protocol_version >= 343 else \
+            0x1A if context.protocol_version >= 332 else \
+            0x19 if context.protocol_version >= 318 else \
+            0x17 if context.protocol_version >= 94 else \
+            0x14 if context.protocol_version >= 70 else \
+            0x0A if context.protocol_version >= 69 else \
+            0x09
 
     packet_name = "held item change"
 

--- a/minecraft/networking/packets/serverbound/play/held_item_change_packet.py
+++ b/minecraft/networking/packets/serverbound/play/held_item_change_packet.py
@@ -1,0 +1,17 @@
+from minecraft.networking.packets import Packet
+
+from minecraft.networking.types import (
+    Short, BitFieldEnum
+)
+
+
+class HeldItemChangePacket(Packet, BitFieldEnum):
+    @staticmethod
+    def get_id(context):
+        return 0x25
+
+    packet_name = "held item change"
+
+    get_definition = staticmethod(lambda context: [
+        {'slot': Short}
+    ])


### PR DESCRIPTION
Added serverbound HeldItemChange packet.
There is a clientbound version but it doesn't seem useful so I didn't bother with it.
Also I only added packet id for protocol for protocol 753 (1.16.3), because I don't know of any easy way for getting ids for previous versions. (Do I need to manually compare every protocol version at wiki.vg to see if it change, or is there an easier way?)