### PR TITLE
Allow reconnecting to the server from a network exception handler

### DIFF
--- a/minecraft/networking/connection.py
+++ b/minecraft/networking/connection.py
@@ -55,6 +55,7 @@ class Connection(object):
         initial_version=None,
         allowed_versions=None,
         handle_exception=None,
+        disconnect_on_exception=True,
         handle_exit=None,
     ):
         """Sets up an instance of this object to be able to connect to a
@@ -93,6 +94,12 @@ class Connection(object):
                                  re-raised from the networking thread after
                                  closing the connection; or the value 'False',
                                  meaning that the exception is never re-raised.
+        :param disconnect_on_exception(bool): A boolean that specifies whether
+                                              or not to forcibly disconnect from
+                                              a server after firing an exception
+                                              handler. This can be set to False if
+                                              you intend to reconnect to the server
+                                              within the exception handler.
         :param handle_exit: A function to be called when a connection to a
                             server terminates, not caused by an exception,
                             and not with the intention to automatically
@@ -145,6 +152,7 @@ class Connection(object):
         self.connected = False
 
         self.handle_exception = handle_exception
+        self.disconnect_on_exception = disconnect_on_exception
         self.exception, self.exc_info = None, None
         self.handle_exit = handle_exit
 
@@ -490,7 +498,8 @@ class Connection(object):
 
         # Record the exception and cleanly terminate the connection.
         self.exception, self.exc_info = exc, exc_info
-        self.disconnect(immediate=True)
+        if self.disconnect_on_exception:
+            self.disconnect(immediate=True)
 
         # If allowed by the final exception handler, re-raise the exception.
         if self.handle_exception is None and not caught:

--- a/minecraft/networking/connection.py
+++ b/minecraft/networking/connection.py
@@ -440,6 +440,7 @@ class Connection(object):
                 except socket.error:
                     pass
                 finally:
+                    self.file_object.close()
                     self.socket.close()
                     self.socket = None
                     if immediate:

--- a/minecraft/networking/connection.py
+++ b/minecraft/networking/connection.py
@@ -442,6 +442,8 @@ class Connection(object):
                 finally:
                     self.socket.close()
                     self.socket = None
+                    if immediate:
+                        self._outgoing_packet_queue.clear()
 
     def _handshake(self, next_state=STATE_PLAYING):
         handshake = serverbound.handshake.HandShakePacket()


### PR DESCRIPTION
Currently, if a network error occurs, such as an EOF, pyCraft forcibly disconnects the connection to the server after calling the handler set with `handle_exception`. This is reasonable in most cases, however, in my case, I would like to use this handler to reconnect to the server without having to catch an exception somewhere else and I can't do it if pyCraft terminates the connection immediately after.

This PR adds a boolean parameter called `disconnect_on_exception` (defaulting to true) to the connection which controls this behavior.

It also fixes a couple issues I noticed could cause edge-case exceptions while debugging this issue.

