### PR TITLE
Update travis-ci build distro to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 python: 3.8
 
 matrix:


### PR DESCRIPTION
Fixes some cryptography error stemming from the fact that the OpenSSL version included in xenial is no longer being supported.

On a related note, does anyone know why travis isn't automatically showing build status in PRs anymore? Can we get this fixed? cc: @ammaraskar 