### PR TITLE
Add tab-complete packets

### DIFF
--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -60,7 +60,7 @@ def get_packets(context):
             FacePlayerPacket
         }
     if context.protocol_later_eq(345) or \
-        context.protocol_earlier_eq(342):
+            context.protocol_earlier_eq(342):
         packets |= {
             TabCompletePacket,
         }

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -18,6 +18,7 @@ from .explosion_packet import ExplosionPacket
 from .sound_effect_packet import SoundEffectPacket
 from .face_player_packet import FacePlayerPacket
 from .join_game_and_respawn_packets import JoinGamePacket, RespawnPacket
+from .tab_complete_packet import TabCompletePacket
 
 
 # Formerly known as state_playing_clientbound.
@@ -57,6 +58,11 @@ def get_packets(context):
     if context.protocol_later_eq(352):
         packets |= {
             FacePlayerPacket
+        }
+    if context.protocol_later_eq(345) or \
+        context.protocol_earlier_eq(342):
+        packets |= {
+            TabCompletePacket,
         }
     return packets
 

--- a/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
@@ -1,5 +1,5 @@
 from minecraft.networking.packets import Packet
-from minecraft.networking.types import VarInt, Boolean, String
+from minecraft.networking.types import VarInt, Boolean, String, MutableRecord
 
 class TabCompletePacket(Packet):
     @staticmethod

--- a/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
@@ -1,0 +1,48 @@
+from minecraft.networking.packets import Packet
+from minecraft.networking.types import VarInt, Boolean, String
+
+class TabCompletePacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x0F if context.protocol_later_eq(741) else \
+               0x10 if context.protocol_later_eq(721) else \
+               0x11 if context.protocol_later_eq(550) else \
+               0x10 if context.protocol_later_eq(345) else \
+               0x0E if context.protocol_later_eq(332) else \
+               0x0F if context.protocol_later_eq(318) else \
+               0x0E if context.protocol_later_eq(70) else \
+               0x3A
+
+    packet_name = 'tab complete'
+
+    fields = 'id', 'start', 'length', 'matches',
+    
+    class TabMatch(MutableRecord):
+        __slots__ = ('match', 'tooltip')
+        
+        def __init__(self, match, tooltip=None):
+            self.match = match
+            self.tooltip = tooltip
+    
+    def read(self, file_object):
+        self.id = VarInt.read(file_object)
+        self.start = VarInt.read(file_object)
+        self.length = VarInt.read(file_object)
+        count = VarInt.read(file_object)
+        self.matches = []
+        for i in range(count):
+            match = String.read(file_object)
+            has_tooltip = Boolean.read(file_object)
+            tooltip = String.read(file_object) if has_tooltip else None
+            tabmatch = TabCompletePacket.TabMatch(match, tooltip)
+            self.matches.append(tabmatch)
+    def write_fields(self, packet_buffer):
+        VarInt.send(self.id, packet_buffer)
+        VarInt.send(self.start, packet_buffer)
+        VarInt.send(self.length, packet_buffer)
+        VarInt.send(len(self.matches), packet_buffer)
+        for tabmatch in self.matches:
+            String.send(tabmatch.match, packet_buffer)
+            Boolean.send(tabmatch.tooltip is not None, packet_buffer)
+            if tabmatch.tooltip is not None:
+                String.send(tabmatch.tooltip, packet_buffer)

--- a/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
@@ -15,7 +15,7 @@ class TabCompletePacket(Packet):
 
     packet_name = 'tab complete'
     @property
-    def fields():
+    def fields(self):
         fields = 'matches',
         if self.context.protocol_later_eq(346):
             fields += 'transaction_id', 'start', 'length',
@@ -23,11 +23,11 @@ class TabCompletePacket(Packet):
 
     class TabMatch(MutableRecord):
         __slots__ = ('match', 'tooltip')
-        
+
         def __init__(self, match, tooltip=None):
             self.match = match
             self.tooltip = tooltip
-    
+
     def read(self, file_object):
         if self.context.protocol_later_eq(346):
             self.transaction_id = VarInt.read(file_object)

--- a/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
@@ -1,6 +1,7 @@
 from minecraft.networking.packets import Packet
 from minecraft.networking.types import VarInt, Boolean, String, MutableRecord
 
+
 class TabCompletePacket(Packet):
     @staticmethod
     def get_id(context):
@@ -14,6 +15,7 @@ class TabCompletePacket(Packet):
                0x3A
 
     packet_name = 'tab complete'
+
     @property
     def fields(self):
         fields = 'matches',
@@ -43,6 +45,7 @@ class TabCompletePacket(Packet):
             tooltip = String.read(file_object) if has_tooltip else None
             tabmatch = TabCompletePacket.TabMatch(match, tooltip)
             self.matches.append(tabmatch)
+
     def write_fields(self, packet_buffer):
         if self.context.protocol_later_eq(346):
             VarInt.send(self.transaction_id, packet_buffer)

--- a/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/clientbound/play/tab_complete_packet.py
@@ -14,9 +14,13 @@ class TabCompletePacket(Packet):
                0x3A
 
     packet_name = 'tab complete'
+    @property
+    def fields():
+        fields = 'matches',
+        if self.context.protocol_later_eq(346):
+            fields += 'transaction_id', 'start', 'length',
+        return fields
 
-    fields = 'id', 'start', 'length', 'matches',
-    
     class TabMatch(MutableRecord):
         __slots__ = ('match', 'tooltip')
         
@@ -25,24 +29,29 @@ class TabCompletePacket(Packet):
             self.tooltip = tooltip
     
     def read(self, file_object):
-        self.id = VarInt.read(file_object)
-        self.start = VarInt.read(file_object)
-        self.length = VarInt.read(file_object)
+        if self.context.protocol_later_eq(346):
+            self.transaction_id = VarInt.read(file_object)
+            self.start = VarInt.read(file_object)
+            self.length = VarInt.read(file_object)
         count = VarInt.read(file_object)
         self.matches = []
         for i in range(count):
             match = String.read(file_object)
-            has_tooltip = Boolean.read(file_object)
+            has_tooltip = False
+            if self.context.protocol_later_eq(357):
+                has_tooltip = Boolean.read(file_object)
             tooltip = String.read(file_object) if has_tooltip else None
             tabmatch = TabCompletePacket.TabMatch(match, tooltip)
             self.matches.append(tabmatch)
     def write_fields(self, packet_buffer):
-        VarInt.send(self.id, packet_buffer)
-        VarInt.send(self.start, packet_buffer)
-        VarInt.send(self.length, packet_buffer)
+        if self.context.protocol_later_eq(346):
+            VarInt.send(self.transaction_id, packet_buffer)
+            VarInt.send(self.start, packet_buffer)
+            VarInt.send(self.length, packet_buffer)
         VarInt.send(len(self.matches), packet_buffer)
         for tabmatch in self.matches:
             String.send(tabmatch.match, packet_buffer)
-            Boolean.send(tabmatch.tooltip is not None, packet_buffer)
-            if tabmatch.tooltip is not None:
-                String.send(tabmatch.tooltip, packet_buffer)
+            if self.context.protocol_later_eq(357):
+                Boolean.send(tabmatch.tooltip is not None, packet_buffer)
+                if tabmatch.tooltip is not None:
+                    String.send(tabmatch.tooltip, packet_buffer)

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -31,6 +31,12 @@ def get_packets(context):
         packets |= {
             TeleportConfirmPacket,
         }
+    # For some reason this packet did not exist on protocols 343 & 344.
+    if context.protocol_later_eq(345) or \
+        context.protocol_earlier_eq(342):
+        packets |= {
+            TabCompletePacket,
+        }
     return packets
 
 
@@ -259,3 +265,21 @@ class UseItemPacket(Packet):
         {'hand': VarInt}])
 
     Hand = RelativeHand
+
+class TabCompletePacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x06 if context.protocol_later_eq(464) else \
+               0x05 if context.protocol_later_eq(389) else \
+               0x04 if context.protocol_later_eq(345) else \
+               0x01 if context.protocol_later_eq(336) else \
+               0x02 if context.protocol_later_eq(318) else \
+               0x01 if context.protocol_later_eq(94) else \
+               0x00 if context.protocol_later_eq(70) else \
+               0x15 if context.protocol_later_eq(69) else \
+               0x14
+    packet_name = "tab complete"
+    get_definition = staticmethod(lambda context: [
+        {'transaction_id': VarInt},
+        {'text': String}
+    ])

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -34,7 +34,7 @@ def get_packets(context):
         }
     # For some reason this packet did not exist on protocols 343 & 344.
     if context.protocol_later_eq(345) or \
-        context.protocol_earlier_eq(342):
+            context.protocol_earlier_eq(342):
         packets |= {
             TabCompletePacket,
         }
@@ -266,4 +266,3 @@ class UseItemPacket(Packet):
         {'hand': VarInt}])
 
     Hand = RelativeHand
-

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -279,7 +279,14 @@ class TabCompletePacket(Packet):
                0x15 if context.protocol_later_eq(69) else \
                0x14
     packet_name = "tab complete"
-    get_definition = staticmethod(lambda context: [
-        {'transaction_id': VarInt},
-        {'text': String}
-    ])
+    @staticmethod
+    def get_definition(context):
+        return [
+            {'transaction_id': VarInt},
+            {'text': String},
+        ] if context.protocol_later_eq(351) else [
+            {'text': String},
+            {'assume_command': Boolean} if context.protocol_later_eq(95),
+            {'has_position': Boolean},
+            {'looked_at_block': Position},
+        ]

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -266,27 +266,3 @@ class UseItemPacket(Packet):
 
     Hand = RelativeHand
 
-class TabCompletePacket(Packet):
-    @staticmethod
-    def get_id(context):
-        return 0x06 if context.protocol_later_eq(464) else \
-               0x05 if context.protocol_later_eq(389) else \
-               0x04 if context.protocol_later_eq(345) else \
-               0x01 if context.protocol_later_eq(336) else \
-               0x02 if context.protocol_later_eq(318) else \
-               0x01 if context.protocol_later_eq(94) else \
-               0x00 if context.protocol_later_eq(70) else \
-               0x15 if context.protocol_later_eq(69) else \
-               0x14
-    packet_name = "tab complete"
-    @staticmethod
-    def get_definition(context):
-        return [
-            {'transaction_id': VarInt},
-            {'text': String},
-        ] if context.protocol_later_eq(351) else [
-            {'text': String},
-            {'assume_command': Boolean} if context.protocol_later_eq(95),
-            {'has_position': Boolean},
-            {'looked_at_block': Position},
-        ]

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -9,6 +9,7 @@ from minecraft.networking.types import (
 )
 
 from .client_settings_packet import ClientSettingsPacket
+from .tab_complete_packet import TabCompletePacket
 
 
 # Formerly known as state_playing_serverbound.

--- a/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
@@ -1,6 +1,7 @@
 from minecraft.networking.types import VarInt, Boolean, Position, String
 from minecraft.networking.packets import Packet
 
+
 class TabCompletePacket(Packet):
     @staticmethod
     def get_id(context):
@@ -14,6 +15,7 @@ class TabCompletePacket(Packet):
                0x15 if context.protocol_later_eq(69) else \
                0x14
     packet_name = 'tab complete'
+
     @property
     def fields(self):
         fields = 'text',
@@ -21,7 +23,9 @@ class TabCompletePacket(Packet):
             fields += 'transaction_id'
         else:
             fields += 'has_position', 'looked_at_block',
-            fields += 'assume_command' if self.context.protocol_later_eq(95) else {}
+            if self.context.protocol_later_eq(95):
+                fields += 'assume_command'
+
     def read(self, file_object):
         self.transaction_id = VarInt.read(file_object) \
             if self.context.protocol_later_eq(351) else None
@@ -32,6 +36,7 @@ class TabCompletePacket(Packet):
             has_position = Boolean.read(file_object)
             if has_position:
                 self.looked_at_block = Position.read(file_object)
+
     def write_fields(self, packet_buffer):
         if self.context.protocol_later_eq(351):
             VarInt.send(self.transaction_id, packet_buffer)

--- a/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
@@ -1,4 +1,5 @@
-from minecraft.networking.types import Packet, VarInt, Boolean, Position
+from minecraft.networking.types import VarInt, Boolean, Position, String
+from minecraft.networking.packets import Packet
 
 class TabCompletePacket(Packet):
     @staticmethod
@@ -14,30 +15,30 @@ class TabCompletePacket(Packet):
                0x14
     packet_name = 'tab complete'
     @property
-    def fields():
+    def fields(self):
         fields = 'text',
-        if context.protocol_later_eq(351):
+        if self.context.protocol_later_eq(351):
             fields += 'transaction_id'
         else:
             fields += 'has_position', 'looked_at_block',
-            fields += 'assume_command' if context.protocol_later_eq(95)
-        ]
+            fields += 'assume_command' if self.context.protocol_later_eq(95) else {}
     def read(self, file_object):
         self.transaction_id = VarInt.read(file_object) \
-            if self.context.protocol_later_eq(351)
+            if self.context.protocol_later_eq(351) else None
         self.text = String.read(file_object)
         if self.context.protocol_earlier_eq(350):
             self.assume_command = Boolean.read(file_object) \
-                if self.context.protocol_later_eq(95)
+                if self.context.protocol_later_eq(95) else None
             has_position = Boolean.read(file_object)
-            self.looked_at_block = Position.read(file_object) if has_position
+            if has_position:
+                self.looked_at_block = Position.read(file_object)
     def write_fields(self, packet_buffer):
-        VarInt.write(self.transaction_id, packet_buffer) \
-            if self.context.protocol_later_eq(351)
-        String.write(self.text, packet_buffer)
+        if self.context.protocol_later_eq(351):
+            VarInt.send(self.transaction_id, packet_buffer)
+        String.send(self.text, packet_buffer)
         if self.context.protocol_earlier_eq(350):
-            Boolean.write(self.assume_command, packet_buffer) \
-                if self.context.protocol_later_eq(95)
-            Boolean.write(self.looked_at_block is not None, packet_buffer)
-            Position.write(self.looked_at_block, packet_buffer) \
-                if self.looked_at_block is not None
+            if self.context.protocol_later_eq(95):
+                Boolean.send(self.assume_command, packet_buffer)
+            Boolean.send(self.looked_at_block is not None, packet_buffer)
+            if self.looked_at_block is not None:
+                Position.send(self.looked_at_block, packet_buffer)

--- a/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
+++ b/minecraft/networking/packets/serverbound/play/tab_complete_packet.py
@@ -1,0 +1,43 @@
+from minecraft.networking.types import Packet, VarInt, Boolean, Position
+
+class TabCompletePacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x06 if context.protocol_later_eq(464) else \
+               0x05 if context.protocol_later_eq(389) else \
+               0x04 if context.protocol_later_eq(345) else \
+               0x01 if context.protocol_later_eq(336) else \
+               0x02 if context.protocol_later_eq(318) else \
+               0x01 if context.protocol_later_eq(94) else \
+               0x00 if context.protocol_later_eq(70) else \
+               0x15 if context.protocol_later_eq(69) else \
+               0x14
+    packet_name = 'tab complete'
+    @property
+    def fields():
+        fields = 'text',
+        if context.protocol_later_eq(351):
+            fields += 'transaction_id'
+        else:
+            fields += 'has_position', 'looked_at_block',
+            fields += 'assume_command' if context.protocol_later_eq(95)
+        ]
+    def read(self, file_object):
+        self.transaction_id = VarInt.read(file_object) \
+            if self.context.protocol_later_eq(351)
+        self.text = String.read(file_object)
+        if self.context.protocol_earlier_eq(350):
+            self.assume_command = Boolean.read(file_object) \
+                if self.context.protocol_later_eq(95)
+            has_position = Boolean.read(file_object)
+            self.looked_at_block = Position.read(file_object) if has_position
+    def write_fields(self, packet_buffer):
+        VarInt.write(self.transaction_id, packet_buffer) \
+            if self.context.protocol_later_eq(351)
+        String.write(self.text, packet_buffer)
+        if self.context.protocol_earlier_eq(350):
+            Boolean.write(self.assume_command, packet_buffer) \
+                if self.context.protocol_later_eq(95)
+            Boolean.write(self.looked_at_block is not None, packet_buffer)
+            Position.write(self.looked_at_block, packet_buffer) \
+                if self.looked_at_block is not None


### PR DESCRIPTION
I've added serverbound and clientbound tab-complete packets. I'm not super fantastic at python, so let me know if anything needs to be adjusted. I've tested it on 1.16.5, 1.12.2, and 1.8.8, and it seems to work well. Thanks!