### PR TITLE
add packets for resource pack handling

### DIFF
--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -44,7 +44,8 @@ def get_packets(context):
         RespawnPacket,
         PluginMessagePacket,
         PlayerListHeaderAndFooterPacket,
-        EntityLookPacket
+        EntityLookPacket,
+        ResourcePackSendPacket
     }
     if context.protocol_earlier_eq(47):
         packets |= {
@@ -357,3 +358,12 @@ class EntityLookPacket(Packet):
         {'pitch': Angle},
         {'on_ground': Boolean}
     ]
+
+
+class ResourcePackSendPacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x38
+    packet_name = "resource pack send"
+    get_definition = staticmethod(lambda context: [{"url": String}, {"hash": String}])
+

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -365,5 +365,7 @@ class ResourcePackSendPacket(Packet):
     def get_id(context):
         return 0x38
     packet_name = "resource pack send"
-    get_definition = staticmethod(lambda context: [{"url": String}, {"hash": String}])
-
+    get_definition = staticmethod(lambda context: [
+        {"url": String},
+        {"hash": String}
+    ])

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -259,3 +259,11 @@ class UseItemPacket(Packet):
         {'hand': VarInt}])
 
     Hand = RelativeHand
+
+
+class ResourcePackStatusPacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x21
+    packet_name = "resource pask status"
+    get_definition = staticmethod(lambda context: [{"result": VarInt}])


### PR DESCRIPTION
Closes #219.

Adds the serverbound and clientbound packets that is needed to accept a server's resource pack.

Co-authored-by: jj136975 <57088933+jj136975@users.noreply.github.com>