### PR TITLE
Working update for 1.17 (with linter fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ matrix:
     - python: 3.8
       env: TOX_ENV=verify-manifest
 
+before_install:
+  - python -m pip install --upgrade virtualenv
+
 install:
-  - pip install --upgrade pip
-  - pip install --upgrade virtualenv
   - pip install tox
   - pip install python-coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: TOX_ENV=verify-manifest
 
 install:
+  - pip install --upgrade pip
+  - pip install --upgrade virtualenv
   - pip install tox
   - pip install python-coveralls
 script:

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -460,6 +460,7 @@ KNOWN_MINECRAFT_VERSION_RECORDS = [
     Version('20w45a',                PRE | 5,  True),
     Version('20w46a',                PRE | 6,  True),
     Version('20w48a',                PRE | 7,  True),
+    Version('1.17',                  755,      True),
 ]
 
 # An OrderedDict mapping the id string of each known Minecraft version to its

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -44,7 +44,8 @@ def get_packets(context):
         RespawnPacket,
         PluginMessagePacket,
         PlayerListHeaderAndFooterPacket,
-        EntityLookPacket
+        EntityLookPacket,
+        ResourcePackSendPacket
     }
     if context.protocol_earlier_eq(47):
         packets |= {
@@ -64,7 +65,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x1F if context.protocol_later_eq(741) else \
+        return 0x21 if context.protocol_later_eq(755) else \
+               0x1F if context.protocol_later_eq(741) else \
                0x20 if context.protocol_later_eq(721) else \
                0x21 if context.protocol_later_eq(550) else \
                0x20 if context.protocol_later_eq(471) else \
@@ -79,7 +81,8 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
 class ServerDifficultyPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0D if context.protocol_later_eq(721) else \
+        return 0x0E if context.protocol_later_eq(755) else \
+               0x0D if context.protocol_later_eq(721) else \
                0x0E if context.protocol_later_eq(550) else \
                0x0D if context.protocol_later_eq(332) else \
                0x0E if context.protocol_later_eq(318) else \
@@ -99,7 +102,8 @@ class ServerDifficultyPacket(Packet):
 class ChatMessagePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0E if context.protocol_later_eq(721) else \
+        return 0x0F if context.protocol_later_eq(755) else \
+               0x0E if context.protocol_later_eq(721) else \
                0x0F if context.protocol_later_eq(550) else \
                0x0E if context.protocol_later_eq(343) else \
                0x0F if context.protocol_later_eq(332) else \
@@ -123,7 +127,8 @@ class ChatMessagePacket(Packet):
 class DisconnectPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x19 if context.protocol_later_eq(741) else \
+        return 0x1A if context.protocol_later_eq(755) else \
+               0x19 if context.protocol_later_eq(741) else \
                0x1A if context.protocol_later_eq(721) else \
                0x1B if context.protocol_later_eq(550) else \
                0x1A if context.protocol_later_eq(471) else \
@@ -141,7 +146,11 @@ class DisconnectPacket(Packet):
 
 class SetCompressionPacket(Packet):
     # Note: removed between protocol versions 47 and 107.
-    id = 0x46
+    @staticmethod
+    def get_id(context):
+        return 0x02 if context.protocol_later_eq(755) else \
+               0x46
+    
     packet_name = "set compression"
     definition = [
         {'threshold': VarInt}]
@@ -186,7 +195,8 @@ class SpawnPlayerPacket(Packet):
 class EntityVelocityPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x46 if context.protocol_later_eq(721) else \
+        return 0x4F if context.protocol_later_eq(755) else \
+               0x46 if context.protocol_later_eq(721) else \
                0x47 if context.protocol_later_eq(707) else \
                0x46 if context.protocol_later_eq(550) else \
                0x45 if context.protocol_later_eq(471) else \
@@ -214,7 +224,8 @@ class EntityVelocityPacket(Packet):
 class EntityPositionDeltaPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x27 if context.protocol_later_eq(741) else \
+        return 0x29 if context.protocol_later_eq(755) else \
+               0x27 if context.protocol_later_eq(741) else \
                0x28 if context.protocol_later_eq(721) else \
                0x29 if context.protocol_later_eq(550) else \
                0x28 if context.protocol_later_eq(389) else \
@@ -253,7 +264,8 @@ class EntityPositionDeltaPacket(Packet):
 class TimeUpdatePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x4E if context.protocol_later_eq(721) else \
+        return 0x58 if context.protocol_later_eq(755) else \
+               0x4E if context.protocol_later_eq(721) else \
                0x4F if context.protocol_later_eq(550) else \
                0x4E if context.protocol_later_eq(471) else \
                0x4A if context.protocol_later_eq(461) else \
@@ -277,7 +289,8 @@ class TimeUpdatePacket(Packet):
 class UpdateHealthPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x49 if context.protocol_later_eq(721) else \
+        return 0x52 if context.protocol_later_eq(755) else \
+               0x49 if context.protocol_later_eq(721) else \
                0x4A if context.protocol_later_eq(707) else \
                0x49 if context.protocol_later_eq(550) else \
                0x48 if context.protocol_later_eq(471) else \
@@ -304,7 +317,8 @@ class UpdateHealthPacket(Packet):
 class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
-        return 0x17 if context.protocol_later_eq(741) else \
+        return 0x18 if context.protocol_later_eq(755) else \
+               0x17 if context.protocol_later_eq(741) else \
                0x18 if context.protocol_later_eq(721) else \
                0x19 if context.protocol_later_eq(550) else \
                0x18 if context.protocol_later_eq(471) else \
@@ -318,7 +332,8 @@ class PluginMessagePacket(AbstractPluginMessagePacket):
 class PlayerListHeaderAndFooterPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x53 if context.protocol_later_eq(721) else \
+        return 0x5E if context.protocol_later_eq(755) else \
+               0x53 if context.protocol_later_eq(721) else \
                0x54 if context.protocol_later_eq(550) else \
                0x53 if context.protocol_later_eq(471) else \
                0x5F if context.protocol_later_eq(461) else \
@@ -340,7 +355,8 @@ class PlayerListHeaderAndFooterPacket(Packet):
 class EntityLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x29 if context.protocol_later_eq(741) else \
+        return 0x3E if context.protocol_later_eq(755) else \
+               0x29 if context.protocol_later_eq(741) else \
                0x2A if context.protocol_later_eq(721) else \
                0x2B if context.protocol_later_eq(550) else \
                0x2A if context.protocol_later_eq(389) else \
@@ -356,4 +372,16 @@ class EntityLookPacket(Packet):
         {'yaw': Angle},
         {'pitch': Angle},
         {'on_ground': Boolean}
+    ]
+
+class ResourcePackSendPacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x3C if context.protocol_later_eq(755) else \
+               0x38
+
+    packet_name = "resource pack send"
+    definition = [
+        {"url": String},
+        {"hash": String}
     ]

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -355,7 +355,7 @@ class PlayerListHeaderAndFooterPacket(Packet):
 class EntityLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x3E if context.protocol_later_eq(755) else \
+        return 0x2B if context.protocol_later_eq(755) else \
                0x29 if context.protocol_later_eq(741) else \
                0x2A if context.protocol_later_eq(721) else \
                0x2B if context.protocol_later_eq(550) else \

--- a/minecraft/networking/packets/clientbound/play/__init__.py
+++ b/minecraft/networking/packets/clientbound/play/__init__.py
@@ -148,7 +148,7 @@ class SetCompressionPacket(Packet):
     # Note: removed between protocol versions 47 and 107.
     @staticmethod
     def get_id(context):
-        return 0x02 if context.protocol_later_eq(755) else \
+        return 0x03 if context.protocol_later_eq(755) else \
                0x46
     
     packet_name = "set compression"

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -49,7 +49,8 @@ class BlockChangePacket(Packet):
 class MultiBlockChangePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x3B if context.protocol_later_eq(741) else \
+        return 0x3F if context.protocol_later_eq(755) else \
+               0x3B if context.protocol_later_eq(741) else \
                0x0F if context.protocol_later_eq(721) else \
                0x10 if context.protocol_later_eq(550) else \
                0x0F if context.protocol_later_eq(343) else \

--- a/minecraft/networking/packets/clientbound/play/block_change_packet.py
+++ b/minecraft/networking/packets/clientbound/play/block_change_packet.py
@@ -9,7 +9,8 @@ from minecraft.networking.types import (
 class BlockChangePacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x0B if context.protocol_later_eq(721) else \
+        return 0x0C if context.protocol_later_eq(755) else \
+               0x0B if context.protocol_later_eq(721) else \
                0x0C if context.protocol_later_eq(550) else \
                0x0B if context.protocol_later_eq(332) else \
                0x0C if context.protocol_later_eq(318) else \

--- a/minecraft/networking/packets/clientbound/play/explosion_packet.py
+++ b/minecraft/networking/packets/clientbound/play/explosion_packet.py
@@ -7,7 +7,8 @@ from minecraft.networking.packets import Packet
 class ExplosionPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x1B if context.protocol_later_eq(741) else \
+        return 0x1C if context.protocol_later_eq(755) else \
+               0x1B if context.protocol_later_eq(741) else \
                0x1C if context.protocol_later_eq(721) else \
                0x1D if context.protocol_later_eq(550) else \
                0x1C if context.protocol_later_eq(471) else \

--- a/minecraft/networking/packets/clientbound/play/face_player_packet.py
+++ b/minecraft/networking/packets/clientbound/play/face_player_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.packets import Packet
 class FacePlayerPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x33 if context.protocol_later_eq(741) else \
+        return 0x37 if context.protocol_later_eq(755) else \
+               0x33 if context.protocol_later_eq(741) else \
                0x34 if context.protocol_later_eq(721) else \
                0x35 if context.protocol_later_eq(550) else \
                0x34 if context.protocol_later_eq(471) else \

--- a/minecraft/networking/packets/clientbound/play/join_game_and_respawn_packets.py
+++ b/minecraft/networking/packets/clientbound/play/join_game_and_respawn_packets.py
@@ -171,7 +171,8 @@ class JoinGamePacket(AbstractDimensionPacket):
 class RespawnPacket(AbstractDimensionPacket):
     @staticmethod
     def get_id(context):
-        return 0x39 if context.protocol_later_eq(741) else \
+        return 0x3D if context.protocol_later_eq(755) else \
+               0x39 if context.protocol_later_eq(741) else \
                0x3A if context.protocol_later_eq(721) else \
                0x3B if context.protocol_later_eq(550) else \
                0x3A if context.protocol_later_eq(471) else \

--- a/minecraft/networking/packets/clientbound/play/join_game_and_respawn_packets.py
+++ b/minecraft/networking/packets/clientbound/play/join_game_and_respawn_packets.py
@@ -58,7 +58,8 @@ class AbstractDimensionPacket(Packet):
 class JoinGamePacket(AbstractDimensionPacket):
     @staticmethod
     def get_id(context):
-        return 0x24 if context.protocol_later_eq(741) else \
+        return 0x26 if context.protocol_later_eq(755) else \
+               0x24 if context.protocol_later_eq(741) else \
                0x25 if context.protocol_later_eq(721) else \
                0x26 if context.protocol_later_eq(550) else \
                0x25 if context.protocol_later_eq(389) else \

--- a/minecraft/networking/packets/clientbound/play/map_packet.py
+++ b/minecraft/networking/packets/clientbound/play/map_packet.py
@@ -8,7 +8,8 @@ from minecraft.networking.types import (
 class MapPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x25 if context.protocol_later_eq(741) else \
+        return 0x27 if context.protocol_later_eq(755) else \
+               0x25 if context.protocol_later_eq(741) else \
                0x26 if context.protocol_later_eq(721) else \
                0x27 if context.protocol_later_eq(550) else \
                0x26 if context.protocol_later_eq(389) else \

--- a/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_list_item_packet.py
@@ -9,7 +9,8 @@ from minecraft.networking.types import (
 class PlayerListItemPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x32 if context.protocol_later_eq(741) else \
+        return 0x36 if context.protocol_later_eq(755) else \
+               0x32 if context.protocol_later_eq(741) else \
                0x33 if context.protocol_later_eq(721) else \
                0x34 if context.protocol_later_eq(550) else \
                0x33 if context.protocol_later_eq(471) else \

--- a/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
@@ -34,7 +34,8 @@ class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
         {'pitch': Float},
         {'flags': Byte},
         {'teleport_id': VarInt} if context.protocol_later_eq(107) else {},
-        {'dismount_vehicle': Boolean} if context.protocol_later_eq(755) else {},
+        {'dismount_vehicle': Boolean} if context.protocol_later_eq(755) \
+             else {},
     ])
 
     # Access the 'x', 'y', 'z' fields as a Vector tuple.

--- a/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
@@ -34,8 +34,8 @@ class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
         {'pitch': Float},
         {'flags': Byte},
         {'teleport_id': VarInt} if context.protocol_later_eq(107) else {},
-        {'dismount_vehicle': Boolean} if context.protocol_later_eq(755) \
-             else {},
+        {'dismount_vehicle': Boolean} if context.protocol_later_eq(755)
+        else {},
     ])
 
     # Access the 'x', 'y', 'z' fields as a Vector tuple.

--- a/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
+++ b/minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py
@@ -1,3 +1,4 @@
+from minecraft.networking.types.basic import Boolean
 from minecraft.networking.packets import Packet
 
 from minecraft.networking.types import (
@@ -9,7 +10,8 @@ from minecraft.networking.types import (
 class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
     @staticmethod
     def get_id(context):
-        return 0x34 if context.protocol_later_eq(741) else \
+        return 0x38 if context.protocol_later_eq(755) else \
+               0x34 if context.protocol_later_eq(741) else \
                0x35 if context.protocol_later_eq(721) else \
                0x36 if context.protocol_later_eq(550) else \
                0x35 if context.protocol_later_eq(471) else \
@@ -32,6 +34,7 @@ class PlayerPositionAndLookPacket(Packet, BitFieldEnum):
         {'pitch': Float},
         {'flags': Byte},
         {'teleport_id': VarInt} if context.protocol_later_eq(107) else {},
+        {'dismount_vehicle':Boolean} if context.protocol_later_eq(755) else {},
     ])
 
     # Access the 'x', 'y', 'z' fields as a Vector tuple.

--- a/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
+++ b/minecraft/networking/packets/clientbound/play/sound_effect_packet.py
@@ -9,7 +9,8 @@ __all__ = 'SoundEffectPacket',
 class SoundEffectPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x51 if context.protocol_later_eq(721) else \
+        return 0x5C if context.protocol_later_eq(755) else \
+               0x51 if context.protocol_later_eq(721) else \
                0x52 if context.protocol_later_eq(550) else \
                0x51 if context.protocol_later_eq(471) else \
                0x4D if context.protocol_later_eq(461) else \

--- a/minecraft/networking/packets/serverbound/play/__init__.py
+++ b/minecraft/networking/packets/serverbound/play/__init__.py
@@ -37,7 +37,8 @@ def get_packets(context):
 class KeepAlivePacket(AbstractKeepAlivePacket):
     @staticmethod
     def get_id(context):
-        return 0x10 if context.protocol_later_eq(712) else \
+        return 0x0F if context.protocol_later_eq(755) else \
+               0x10 if context.protocol_later_eq(712) else \
                0x0F if context.protocol_later_eq(471) else \
                0x10 if context.protocol_later_eq(464) else \
                0x0E if context.protocol_later_eq(389) else \
@@ -53,7 +54,8 @@ class KeepAlivePacket(AbstractKeepAlivePacket):
 class ChatPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x03 if context.protocol_later_eq(464) else \
+        return 0x03 if context.protocol_later_eq(755) else \
+               0x03 if context.protocol_later_eq(464) else \
                0x02 if context.protocol_later_eq(389) else \
                0x01 if context.protocol_later_eq(343) else \
                0x02 if context.protocol_later_eq(336) else \
@@ -79,7 +81,8 @@ class ChatPacket(Packet):
 class PositionAndLookPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x13 if context.protocol_later_eq(712) else \
+        return 0x12 if context.protocol_later_eq(755) else \
+               0x13 if context.protocol_later_eq(712) else \
                0x12 if context.protocol_later_eq(471) else \
                0x13 if context.protocol_later_eq(464) else \
                0x11 if context.protocol_later_eq(389) else \
@@ -126,7 +129,8 @@ class TeleportConfirmPacket(Packet):
 class AnimationPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2C if context.protocol_later_eq(738) else \
+        return 0x2C if context.protocol_later_eq(755) else \
+               0x2C if context.protocol_later_eq(738) else \
                0x2B if context.protocol_later_eq(712) else \
                0x2A if context.protocol_later_eq(468) else \
                0x29 if context.protocol_later_eq(464) else \
@@ -150,7 +154,8 @@ class AnimationPacket(Packet):
 class ClientStatusPacket(Packet, Enum):
     @staticmethod
     def get_id(context):
-        return 0x04 if context.protocol_later_eq(464) else \
+        return 0x04 if context.protocol_later_eq(755) else \
+               0x04 if context.protocol_later_eq(464) else \
                0x03 if context.protocol_later_eq(389) else \
                0x02 if context.protocol_later_eq(343) else \
                0x03 if context.protocol_later_eq(336) else \
@@ -175,7 +180,8 @@ class ClientStatusPacket(Packet, Enum):
 class PluginMessagePacket(AbstractPluginMessagePacket):
     @staticmethod
     def get_id(context):
-        return 0x0B if context.protocol_later_eq(464) else \
+        return 0x0A if context.protocol_later_eq(755) else \
+               0x0B if context.protocol_later_eq(464) else \
                0x0A if context.protocol_later_eq(389) else \
                0x09 if context.protocol_later_eq(345) else \
                0x08 if context.protocol_later_eq(343) else \
@@ -201,7 +207,8 @@ class PlayerBlockPlacementPacket(Packet):
 
     @staticmethod
     def get_id(context):
-        return 0x2E if context.protocol_later_eq(738) else \
+        return 0x2E if context.protocol_later_eq(755) else \
+               0x2E if context.protocol_later_eq(738) else \
                0x2D if context.protocol_later_eq(712) else \
                0x2C if context.protocol_later_eq(468) else \
                0x2B if context.protocol_later_eq(464) else \
@@ -240,7 +247,8 @@ class PlayerBlockPlacementPacket(Packet):
 class UseItemPacket(Packet):
     @staticmethod
     def get_id(context):
-        return 0x2F if context.protocol_later_eq(738) else \
+        return 0x2F if context.protocol_later_eq(755) else \
+               0x2F if context.protocol_later_eq(738) else \
                0x2E if context.protocol_later_eq(712) else \
                0x2D if context.protocol_later_eq(468) else \
                0x2C if context.protocol_later_eq(464) else \
@@ -259,3 +267,12 @@ class UseItemPacket(Packet):
         {'hand': VarInt}])
 
     Hand = RelativeHand
+
+class ResourcePackStatusPacket(Packet):
+    @staticmethod
+    def get_id(context):
+        return 0x21
+    packet_name = "resource pask status"
+    definition = [
+        {"result": VarInt}
+    ]


### PR DESCRIPTION
@MisterSoandSo made a 1.17 compatibility update (PR #230), however it failed due to flake8 flagging an overlength line in [minecraft/networking/packets/clientbound/play/player_position_and_look_packet.py](https://github.com/ammaraskar/pyCraft/commit/37bd22172ceab927878ae19ed16c5b8a9c044763#diff-39f42c236e717748b70e4d3065132a1d28189815bd87f63b0918a12a93c7a335) from 37bd22172ceab927878ae19ed16c5b8a9c044763.